### PR TITLE
Fixing node_exporter config

### DIFF
--- a/grafana/monitoring-installer.sh
+++ b/grafana/monitoring-installer.sh
@@ -227,14 +227,15 @@ install_exporter() {
     echo "    --collector.bonding \\"
     echo "    --collector.hwmon \\"
     echo "    --collector.arp \\"
-    echo "    --web.listen-address=:9100 \\"
+    echo "    --web.listen-address=127.0.0.1:9100 \\"
     echo "    --web.telemetry-path=\"/metrics\""
     echo ""
     echo "[Install]"
     echo "WantedBy=multi-user.target"
-  }>>node_exporter.service
+  } >node_exporter.service
   sudo cp node_exporter.service /etc/systemd/system/node_exporter.service
 
+  sudo systemctl daemon-reload
   sudo systemctl start node_exporter
   sudo systemctl enable node_exporter
 


### PR DESCRIPTION
Fixing the following:
- When calling again the same script, the node_exporter.service is appended multiple times with the same config, thus failing to start
- Binding it to 127.0.0.1 for security