### PR TITLE
Avoid the installer to crash if Prometheus is already installed

### DIFF
--- a/grafana/monitoring-installer.sh
+++ b/grafana/monitoring-installer.sh
@@ -88,8 +88,8 @@ install_prometheus() {
   mkdir prometheus
   tar xvf prometheus.tar.gz -C prometheus --strip-components=1
   echo "Installing..."
-  sudo useradd -M -r -s /bin/false prometheus
-  sudo mkdir /etc/prometheus /var/lib/prometheus
+  id -u prometheus &>/dev/null || sudo useradd -M -r -s /bin/false prometheus
+  sudo mkdir -p /etc/prometheus /var/lib/prometheus
   sudo apt-get install -y apt-transport-https
   cd prometheus
   sudo cp {prometheus,promtool} /usr/local/bin/


### PR DESCRIPTION
Avoid the installer to crash if Prometheus is already installed. It currently crashes because the user and directories already exists, which is a simple fix.