### PR TITLE
fix: uniformize data sources

### DIFF
--- a/grafana/dashboards/c_chain.json
+++ b/grafana/dashboards/c_chain.json
@@ -37,9 +37,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -120,9 +118,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "round(increase(avalanche_C_blks_accepted_count{job=\"avalanchego\"}[1m]))>0",
           "interval": "",
@@ -134,9 +130,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -217,9 +211,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "round(increase(avalanche_C_blks_rejected_count{job=\"avalanchego\"}[1m]))>0",
@@ -233,9 +225,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "The average time between a block's issuance and acceptance by this node over the last 5 minutes.",
       "fieldConfig": {
         "defaults": {
@@ -314,9 +304,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "rate(avalanche_C_blks_accepted_sum{job=\"avalanchego\"}[5m]) / rate(avalanche_C_blks_accepted_count{job=\"avalanchego\"}[5m])",
           "interval": "",
           "legendFormat": "Avg Acceptance Latency",
@@ -327,9 +315,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "The average time between a block's issuance and rejection by this node over the last 5 minutes.",
       "fieldConfig": {
         "defaults": {
@@ -411,9 +397,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "rate(avalanche_C_blks_rejected_sum{job=\"avalanchego\"}[5m]) / rate(avalanche_C_blks_rejected_count{job=\"avalanchego\"}[5m])",
           "interval": "",
           "legendFormat": "Avg Rejection Latency",
@@ -424,9 +408,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -502,9 +484,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "avalanche_C_blks_processing{job=\"avalanchego\"}>0",
           "interval": "",
@@ -516,9 +496,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -594,9 +572,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "avalanche_C_polls > 0",
           "interval": "",
@@ -608,9 +584,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Measures how much of each second is being spent handling different kinds of messages on the C-Chain.\nThe value for chits, for example, is the number of seconds spent handling chits messages per second, over the last 30 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -690,9 +664,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_pull_query_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -700,9 +672,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_push_query_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -710,9 +680,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_chits_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -720,9 +688,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_accepted_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -730,9 +696,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_get_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -740,9 +704,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_put_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -750,9 +712,7 @@
           "refId": "F"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_multiput_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -760,9 +720,7 @@
           "refId": "G"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_get_ancestors_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -770,9 +728,7 @@
           "refId": "H"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_get_failed_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -780,9 +736,7 @@
           "refId": "I"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_query_failed_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -790,9 +744,7 @@
           "refId": "J"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_get_accepted_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -800,9 +752,7 @@
           "refId": "K"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_get_ancestors_failed_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -810,9 +760,7 @@
           "refId": "L"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_app_request_sum{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -821,9 +769,7 @@
           "refId": "M"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_app_request_failed_sum{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -832,9 +778,7 @@
           "refId": "N"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_app_response_sum{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -843,9 +787,7 @@
           "refId": "O"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_app_gossip_sum{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -858,9 +800,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Percentage of queries for which we receive chits on time.",
       "fieldConfig": {
         "defaults": {
@@ -944,9 +884,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "(increase(avalanche_C_handler_chits_count{job=\"avalanchego\"}[5m]) + 1) / (increase(avalanche_C_handler_chits_count{job=\"avalanchego\"}[5m]) + increase(avalanche_C_handler_query_failed_count{job=\"avalanchego\"}[5m]) + 1)",
           "instant": false,
@@ -959,9 +897,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Measures how long each kind of request on the C-Chain takes to handle.\nThe value for chits, for example, is how long, in seconds, it takes to handle a chits message.",
       "fieldConfig": {
         "defaults": {
@@ -1041,9 +977,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_pull_query_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_pull_query_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1051,9 +985,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_push_query_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_push_query_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1061,9 +993,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_chits_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_chits_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1071,9 +1001,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_accepted_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_accepted_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1081,9 +1009,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_get_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_get_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1091,9 +1017,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_put_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_put_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1101,9 +1025,7 @@
           "refId": "F"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_multiput_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_multi_put_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1111,9 +1033,7 @@
           "refId": "G"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_get_ancestors_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_get_ancestors_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1121,9 +1041,7 @@
           "refId": "H"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_get_failed_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_get_failed_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1131,9 +1049,7 @@
           "refId": "I"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_query_failed_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_query_failed_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1141,9 +1057,7 @@
           "refId": "J"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_get_accepted_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_get_accepted_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1151,9 +1065,7 @@
           "refId": "K"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_get_ancestors_failed_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_get_ancestors_failed_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1161,9 +1073,7 @@
           "refId": "L"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_app_request_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_app_request_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -1172,9 +1082,7 @@
           "refId": "M"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_app_request_failed_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_app_request_failed_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -1183,9 +1091,7 @@
           "refId": "N"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_app_response_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_app_response_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -1194,9 +1100,7 @@
           "refId": "O"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_app_gossip_sum{job=\"avalanchego\"}[5m])/rate(avalanche_C_handler_app_gossip_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -1209,9 +1113,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1291,9 +1193,7 @@
       "pluginVersion": "8.0.6",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "avalanche_C_handler_unprocessed_msgs_len",
           "interval": "",
@@ -1305,9 +1205,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1387,9 +1285,7 @@
       "pluginVersion": "8.0.6",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_C_handler_expired[1m])",
           "interval": "",
@@ -1401,9 +1297,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "The total stake of validators currently \"benched\" due to poor query responsiveness. Queries to these validators will immediately timeout until they are removed from the \"bench.\"",
       "fieldConfig": {
         "defaults": {
@@ -1485,9 +1379,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "avg_over_time(avalanche_C_benchlist_benched_weight{job=\"avalanchego\"}[15m]) / 10^9",
           "interval": "",
@@ -1499,9 +1391,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Measures how many of each kind of message are received per second on the C-Chain.",
       "fieldConfig": {
         "defaults": {
@@ -1581,9 +1471,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_pull_query_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1591,9 +1479,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_push_query_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1601,9 +1487,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_chits_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1611,9 +1495,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_accepted_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1621,9 +1503,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_get_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1631,9 +1511,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_put_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1641,9 +1519,7 @@
           "refId": "F"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_multi_put_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1651,9 +1527,7 @@
           "refId": "G"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_get_ancestors_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1661,9 +1535,7 @@
           "refId": "H"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_get_failed_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1671,9 +1543,7 @@
           "refId": "I"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_query_failed_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1681,9 +1551,7 @@
           "refId": "J"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_get_accepted_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1691,9 +1559,7 @@
           "refId": "K"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_get_ancestors_failed_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1701,9 +1567,7 @@
           "refId": "L"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_app_request_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -1712,9 +1576,7 @@
           "refId": "M"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_app_request_failed_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -1723,9 +1585,7 @@
           "refId": "N"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_app_response_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -1734,9 +1594,7 @@
           "refId": "O"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_C_handler_app_gossip_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -1749,9 +1607,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Hit rate for the cache where the key is the byte representation of the block, and the value is the block's ID",
       "fieldConfig": {
         "defaults": {
@@ -1827,9 +1683,7 @@
       },
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "increase(avalanche_C_vm_chain_state_bytes_to_id_cache_hit[5m])/(increase(avalanche_C_vm_chain_state_bytes_to_id_cache_hit[5m])+increase(avalanche_C_vm_chain_state_bytes_to_id_cache_miss[5m]))",
@@ -1843,9 +1697,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Hit rate for the decided block cache",
       "fieldConfig": {
         "defaults": {
@@ -1921,9 +1773,7 @@
       },
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "increase(avalanche_C_vm_chain_state_decided_cache_hit[5m])/(increase(avalanche_C_vm_chain_state_decided_cache_hit[5m])+increase(avalanche_C_vm_chain_state_decided_cache_miss[5m]))",
@@ -1937,9 +1787,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Hit rate for the missing block cache",
       "fieldConfig": {
         "defaults": {
@@ -2016,9 +1864,7 @@
       },
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "increase(avalanche_C_vm_chain_state_missing_cache_hit[5m])/(increase(avalanche_C_vm_chain_state_missing_cache_hit[5m])+increase(avalanche_C_vm_chain_state_missing_cache_miss[5m]))",
@@ -2032,9 +1878,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Hit rate for the unverified block cache",
       "fieldConfig": {
         "defaults": {
@@ -2110,9 +1954,7 @@
       },
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "increase(avalanche_C_vm_chain_state_unverified_cache_hit[5m])/(increase(avalanche_C_vm_chain_state_unverified_cache_hit[5m])+increase(avalanche_C_vm_chain_state_unverified_cache_miss[5m]))",

--- a/grafana/dashboards/database.json
+++ b/grafana/dashboards/database.json
@@ -27,7 +27,7 @@
   ],
   "panels": [
     {
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "Database read rate. Note that these reads may be from caches and not from disk.",
       "fieldConfig": {
         "defaults": {
@@ -117,7 +117,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "Database write rate.",
       "fieldConfig": {
         "defaults": {

--- a/grafana/dashboards/machine.json
+++ b/grafana/dashboards/machine.json
@@ -80,9 +80,7 @@
           }
         ]
       },
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -177,9 +175,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "",
       "fill": 1,
       "fillGradient": 0,
@@ -257,9 +253,7 @@
       }
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Include I/O from applications other than AvalancheGo",
       "fieldConfig": {
         "defaults": {
@@ -354,9 +348,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Includes I/O from applications other than AvalancheGo",
       "fieldConfig": {
         "defaults": {
@@ -430,18 +422,14 @@
       "pluginVersion": "8.0.5",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "rate(node_disk_read_bytes_total[5m])",
           "interval": "",
           "legendFormat": "Read {{device}}",
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "rate(node_disk_written_bytes_total[5m])",
           "hide": false,
           "interval": "",
@@ -492,9 +480,7 @@
           }
         ]
       },
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -573,9 +559,7 @@
       "pluginVersion": "8.0.5",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "100 * (node_memory_MemTotal_bytes{job=~\"avalanchego-machine\"} - node_memory_MemFree_bytes{job=~\"avalanchego-machine\"} - node_memory_Buffers_bytes{job=~\"avalanchego-machine\"} - node_memory_Cached_bytes{job=~\"avalanchego-machine\"}) / node_memory_MemTotal_bytes{job=~\"avalanchego-machine\"}",
           "interval": "",
@@ -622,9 +606,7 @@
         "noDataState": "no_data",
         "notifications": []
       },
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -713,9 +695,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of parallel execution threads in the client runtime",
       "fieldConfig": {
         "defaults": {
@@ -787,9 +767,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "avalanche_go_goroutines{job=~\"avalanchego\"}",
           "interval": "",
@@ -802,9 +780,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of open file handles the client is keeping",
       "fieldConfig": {
         "defaults": {
@@ -876,9 +852,7 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "avalanche_process_open_fds{job=~\"avalanchego\"}",
           "legendFormat": "Open files",
@@ -886,9 +860,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": false,
           "expr": "avalanche_process_max_fds{job=~\"avalanchego\"}",

--- a/grafana/dashboards/main.json
+++ b/grafana/dashboards/main.json
@@ -38,9 +38,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Stake weighted average uptime of your node, as reported by network peers. If this falls below 80% node probably won't be rewarded for the current staking period.",
       "fieldConfig": {
         "defaults": {
@@ -105,9 +103,7 @@
       "pluginVersion": "9.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "avalanche_network_node_uptime_weighted_average{job=\"avalanchego\"}",
           "interval": "",
@@ -119,9 +115,7 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Percentage of the stake that view your node as sufficiently online and correct to vote that node be awarded at the end of the staking period.",
       "fieldConfig": {
         "defaults": {
@@ -182,9 +176,7 @@
       "pluginVersion": "9.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "avalanche_network_node_uptime_rewarding_stake{job=\"avalanchego\"}",
           "interval": "",
@@ -196,9 +188,7 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of accepted and rejected blocks on the X chain in the last minute",
       "fieldConfig": {
         "defaults": {
@@ -286,9 +276,7 @@
       "pluginVersion": "8.0.5",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "round(increase(avalanche_X_blks_accepted_count{job=\"avalanchego\"}[1m]))>0",
@@ -298,9 +286,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "round(increase(avalanche_X_blks_rejected_count{job=\"avalanchego\"}[1m]))>0",
@@ -315,9 +301,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of X-Chain blocks this node has proposed on the network in the last day. Since block production on P-Chain is usually below the target rate, every node proposes P blocks.",
       "fieldConfig": {
         "defaults": {
@@ -362,9 +346,7 @@
       "pluginVersion": "9.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "round(increase(avalanche_X_blks_built{job=\"avalanchego\"}[1d]))",
@@ -378,9 +360,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of accepted and rejected blocks on the P chain in the last minute.",
       "fieldConfig": {
         "defaults": {
@@ -467,9 +447,7 @@
       "pluginVersion": "8.0.5",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "round(increase(avalanche_P_blks_accepted_count{job=\"avalanchego\"}[1m]))>0",
           "interval": "",
@@ -477,9 +455,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "round(increase(avalanche_P_blks_rejected_count{job=\"avalanchego\"}[1m]))>0",
           "hide": false,
@@ -492,9 +468,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of P-Chain blocks this node has proposed on the network in the last day. Since block production on P-Chain is usually below the target rate, every node proposes P blocks.",
       "fieldConfig": {
         "defaults": {
@@ -539,9 +513,7 @@
       "pluginVersion": "9.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "round(increase(avalanche_P_blks_built{job=\"avalanchego\"}[1d]))",
           "interval": "",
@@ -553,9 +525,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Percentage of CPU used",
       "fieldConfig": {
         "defaults": {
@@ -615,9 +585,7 @@
       "pluginVersion": "9.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "(1 - avg(irate(node_cpu_seconds_total{job=~\"avalanchego-machine\", mode=\"idle\"}[1m])) by (instance)) * 100",
           "interval": "",
           "legendFormat": "",
@@ -628,9 +596,7 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Percentage of storage filled",
       "fieldConfig": {
         "defaults": {
@@ -690,9 +656,7 @@
       "pluginVersion": "9.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "max(((node_filesystem_size_bytes{job=~\"avalanchego-machine\", fstype=~\"ext4|vfat\"} - node_filesystem_free_bytes{job=~\"avalanchego-machine\", fstype=~\"ext4|vfat\"}) / node_filesystem_size_bytes{job=~\"avalanchego-machine\", fstype=~\"ext4|vfat\"}) * 100) by (instance)",
           "interval": "",
           "legendFormat": "",
@@ -703,9 +667,7 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of currently failing internal health checks",
       "fieldConfig": {
         "defaults": {
@@ -758,9 +720,7 @@
       "pluginVersion": "9.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "avalanche_health_checks_failing{job=\"avalanchego\"}",
           "interval": "",
           "legendFormat": "",
@@ -771,9 +731,7 @@
       "type": "gauge"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Average time to get a response from a peer",
       "fieldConfig": {
         "defaults": {
@@ -833,9 +791,7 @@
       "pluginVersion": "9.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "avalanche_requests_average_latency",
           "interval": "",
@@ -847,9 +803,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Amount of AVAX currently staked",
       "fieldConfig": {
         "defaults": {
@@ -895,9 +849,7 @@
       "pluginVersion": "9.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "avalanche_P_vm_total_staked{job=\"avalanchego\"}/1000000000",
           "interval": "",
@@ -909,9 +861,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Amount of network stake node is currently connected to",
       "fieldConfig": {
         "defaults": {
@@ -967,9 +917,7 @@
       "pluginVersion": "9.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "avalanche_P_vm_percent_connected{job=\"avalanchego\"}",
           "interval": "",
           "legendFormat": "",
@@ -980,9 +928,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of peers node is connected to",
       "fieldConfig": {
         "defaults": {
@@ -1068,9 +1014,7 @@
       "pluginVersion": "8.0.5",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "avalanche_network_peers{job=\"avalanchego\"}",
           "interval": "",
           "legendFormat": "Peers",
@@ -1081,9 +1025,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of accepted and rejected blocks on the C chain in the last minute.",
       "fieldConfig": {
         "defaults": {
@@ -1170,9 +1112,7 @@
       "pluginVersion": "8.0.5",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "round(increase(avalanche_C_blks_accepted_count{job=\"avalanchego\"}[1m]))>0",
           "interval": "",
@@ -1180,9 +1120,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "round(increase(avalanche_C_blks_rejected_count{job=\"avalanchego\"}[1m]))>0",
           "hide": false,
@@ -1195,9 +1133,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of blocks this node has proposed on the C-Chain in the last day. Since C-Chain blocks are produced at a fast rate, block producers are selected by stake weight.",
       "fieldConfig": {
         "defaults": {
@@ -1246,9 +1182,7 @@
       "pluginVersion": "9.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "round(increase(avalanche_C_blks_built{job=\"avalanchego\"}[1d]))",
           "interval": "",
@@ -1260,9 +1194,7 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of blocks accepted in the last minute",
       "fieldConfig": {
         "defaults": {
@@ -1308,9 +1240,7 @@
       "pluginVersion": "9.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "round(increase(avalanche_X_blks_accepted_count{job=\"avalanchego\"}[1m]))",
           "interval": "",
@@ -1319,9 +1249,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "round(increase(avalanche_P_blks_accepted_count{job=\"avalanchego\"}[1m]))",
           "hide": false,
@@ -1331,9 +1259,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "round(increase(avalanche_C_blks_accepted_count{job=\"avalanchego\"}[1m]))",
           "hide": false,
           "interval": "",
@@ -1345,9 +1271,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of blocks currently being processed by the node",
       "fieldConfig": {
         "defaults": {
@@ -1401,9 +1325,7 @@
       "pluginVersion": "9.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "avalanche_X_blks_processing{job=\"avalanchego\"}",
           "interval": "",
@@ -1412,9 +1334,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "avalanche_P_blks_processing{job=\"avalanchego\"}",
           "hide": false,
@@ -1424,9 +1344,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "avalanche_C_blks_processing{job=\"avalanchego\"}",
           "hide": false,
           "interval": "",
@@ -1438,9 +1356,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of peers currently being benched (ignored) by the node",
       "fieldConfig": {
         "defaults": {
@@ -1485,18 +1401,14 @@
       "pluginVersion": "9.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "avalanche_X_benchlist_benched_num{job=\"avalanchego\"}",
           "interval": "",
           "legendFormat": "X Chain",
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "avalanche_P_benchlist_benched_num{job=\"avalanchego\"}",
           "hide": false,
           "interval": "",
@@ -1504,9 +1416,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "avalanche_C_benchlist_benched_num{job=\"avalanchego\"}",
           "hide": false,
           "interval": "",
@@ -1518,9 +1428,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Percentage of successful queries per chain in the last minute",
       "fieldConfig": {
         "defaults": {
@@ -1576,18 +1484,14 @@
       "pluginVersion": "9.2.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "(increase(avalanche_X_handler_chits_count{job=\"avalanchego\"}[1m]) + 1) / (increase(avalanche_X_handler_chits_count{job=\"avalanchego\"}[1m]) + increase(avalanche_X_handler_query_failed_count{job=\"avalanchego\"}[1m]) + 1)",
           "interval": "",
           "legendFormat": "X Chain",
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "(increase(avalanche_P_handler_chits_count{job=\"avalanchego\"}[1m]) + 1) / (increase(avalanche_P_handler_chits_count{job=\"avalanchego\"}[1m]) + increase(avalanche_P_handler_query_failed_count{job=\"avalanchego\"}[1m]) + 1)",
           "hide": false,
           "interval": "",
@@ -1595,9 +1499,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "(increase(avalanche_C_handler_chits_count{job=\"avalanchego\"}[1m]) + 1) / (increase(avalanche_C_handler_chits_count{job=\"avalanchego\"}[1m]) + increase(avalanche_C_handler_query_failed_count{job=\"avalanchego\"}[1m]) + 1)",
           "hide": false,
           "interval": "",
@@ -1609,9 +1511,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "How long each database operation is taking on average",
       "fieldConfig": {
         "defaults": {
@@ -1689,9 +1589,7 @@
       "pluginVersion": "8.0.5",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_db_put_sum{job=\"avalanchego\"}[5m])/increase(avalanche_db_put_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1699,9 +1597,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_db_get_sum{job=\"avalanchego\"}[5m])/increase(avalanche_db_get_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1709,9 +1605,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_db_delete_sum{job=\"avalanchego\"}[5m])/increase(avalanche_db_delete_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1719,9 +1613,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_db_has_sum{job=\"avalanchego\"}[5m])/increase(avalanche_db_has_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1729,9 +1621,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_db_compact_size_sum{job=\"avalanchego\"}[5m])/increase(avalanche_db_compact_size_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1739,9 +1629,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_db_batch_put_sum{job=\"avalanchego\"}[5m])/increase(avalanche_db_batch_put_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1749,9 +1637,7 @@
           "refId": "F"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_db_batch_delete_sum{job=\"avalanchego\"}[5m])/increase(avalanche_db_batch_delete_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1759,9 +1645,7 @@
           "refId": "G"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_db_batch_reset_sum{job=\"avalanchego\"}[5m])/increase(avalanche_db_batch_reset_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1769,9 +1653,7 @@
           "refId": "H"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_db_batch_replay_sum{job=\"avalanchego\"}[5m])/increase(avalanche_db_batch_replay_count{job=\"avalanchego\"}[5m])",
           "interval": "",

--- a/grafana/dashboards/network.json
+++ b/grafana/dashboards/network.json
@@ -38,9 +38,7 @@
   "panels": [
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -53,9 +51,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Stake weighted average uptime of your node, as reported by network peers. If this falls below 80% node probably won't be rewarded for the current staking period.",
       "fieldConfig": {
         "defaults": {
@@ -161,9 +157,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Percentage of the stake that view your node as sufficiently online and correct to vote that node be awarded at the end of the staking period.",
       "fieldConfig": {
         "defaults": {
@@ -301,9 +295,7 @@
         "noDataState": "no_data",
         "notifications": []
       },
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of network peers the node is connected to",
       "fieldConfig": {
         "defaults": {
@@ -390,9 +382,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Shows the amount of time this node will wait for a response to a request before considering the request failed, and the average time it takes to get a response to a request.",
       "fieldConfig": {
         "defaults": {
@@ -488,9 +478,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of outstanding requests related to consensus/bootstrapping. Doesn't include handshake messages.",
       "fieldConfig": {
         "defaults": {
@@ -576,9 +564,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "From all chains",
       "fieldConfig": {
         "defaults": {
@@ -791,9 +777,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "From all chains",
       "fieldConfig": {
         "defaults": {
@@ -993,9 +977,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "From all chains",
       "fieldConfig": {
         "defaults": {
@@ -1072,9 +1054,7 @@
       "pluginVersion": "8.0.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_accepted_received_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1082,9 +1062,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_get_accepted_received_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1092,9 +1070,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_get_accepted_frontier_received_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1102,9 +1078,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_get_ancestors_received_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1112,9 +1086,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_put_received_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1122,9 +1094,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_multi_put_received_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1132,9 +1102,7 @@
           "refId": "F"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_get_version_received_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1142,9 +1110,7 @@
           "refId": "G"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_get_peerlist_received_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1152,9 +1118,7 @@
           "refId": "H"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_pull_query_received_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1162,9 +1126,7 @@
           "refId": "I"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_push_query_received_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1172,9 +1134,7 @@
           "refId": "J"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_version_received_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1182,9 +1142,7 @@
           "refId": "K"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_ping_received_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1192,9 +1150,7 @@
           "refId": "L"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_pong_received_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1202,9 +1158,7 @@
           "refId": "M"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_get_received_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1212,9 +1166,7 @@
           "refId": "N"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_chits_received_bytes{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -1223,9 +1175,7 @@
           "refId": "O"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_app_gossip_received_bytes{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -1234,9 +1184,7 @@
           "refId": "P"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_app_request_received_bytes{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -1245,9 +1193,7 @@
           "refId": "Q"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_app_response_received_bytes{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -1260,9 +1206,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "From all chains",
       "fieldConfig": {
         "defaults": {
@@ -1339,9 +1283,7 @@
       "pluginVersion": "8.0.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_accepted_sent_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1349,9 +1291,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_get_accepted_sent_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1359,9 +1299,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_get_accepted_frontier_sent_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1369,9 +1307,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_get_ancestors_sent_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1379,9 +1315,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_put_sent_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1389,9 +1323,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_multi_put_sent_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1399,9 +1331,7 @@
           "refId": "F"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_get_version_sent_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1409,9 +1339,7 @@
           "refId": "G"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_get_peerlist_sent_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1419,9 +1347,7 @@
           "refId": "H"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_pull_query_sent_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1429,9 +1355,7 @@
           "refId": "I"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_push_query_sent_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1439,9 +1363,7 @@
           "refId": "J"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_version_sent_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1449,9 +1371,7 @@
           "refId": "K"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_ping_sent_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1459,9 +1379,7 @@
           "refId": "L"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_pong_sent_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1469,9 +1387,7 @@
           "refId": "M"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_get_sent_bytes{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1479,9 +1395,7 @@
           "refId": "N"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_chits_sent_bytes{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -1490,9 +1404,7 @@
           "refId": "O"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_app_gossip_sent_bytes{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -1501,9 +1413,7 @@
           "refId": "P"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_app_request_sent_bytes{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -1512,9 +1422,7 @@
           "refId": "Q"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_network_app_response_sent_bytes{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -1527,9 +1435,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "From all chains",
       "fieldConfig": {
         "defaults": {
@@ -1606,9 +1512,7 @@
       "pluginVersion": "8.0.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_accepted_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_accepted_received{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1616,9 +1520,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_get_accepted_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_get_accepted_received{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1626,9 +1528,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_get_accepted_frontier_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_get_accepted_frontier_received{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1636,9 +1536,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_get_ancestors_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_get_ancestors_received{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1646,9 +1544,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_put_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_put_received{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1656,9 +1552,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_multi_put_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_multi_put_received{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1666,9 +1560,7 @@
           "refId": "F"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_get_version_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_get_version_received{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1676,9 +1568,7 @@
           "refId": "G"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_get_peerlist_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_get_peerlist_received{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1686,9 +1576,7 @@
           "refId": "H"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_pull_query_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_pull_query_received{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1696,9 +1584,7 @@
           "refId": "I"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_push_query_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_push_query_received{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1706,9 +1592,7 @@
           "refId": "J"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_version_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_version_received{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1716,9 +1600,7 @@
           "refId": "K"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_ping_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_ping_received{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1726,9 +1608,7 @@
           "refId": "L"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_pong_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_pong_received{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1736,9 +1616,7 @@
           "refId": "M"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_get_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_get_received{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1746,9 +1624,7 @@
           "refId": "N"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_chits_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_chits_received{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -1757,9 +1633,7 @@
           "refId": "O"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_app_gossip_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_app_gossip_received{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -1768,9 +1642,7 @@
           "refId": "P"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_app_request_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_app_request_received{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -1779,9 +1651,7 @@
           "refId": "Q"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_app_response_received_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_app_response_received{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -1794,9 +1664,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "From all chains",
       "fieldConfig": {
         "defaults": {
@@ -1873,9 +1741,7 @@
       "pluginVersion": "8.0.3",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_accepted_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_accepted_sent{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1883,9 +1749,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_get_accepted_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_get_accepted_sent{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1893,9 +1757,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_get_accepted_frontier_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_get_accepted_frontier_sent{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1903,9 +1765,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_get_ancestors_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_get_ancestors_sent{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1913,9 +1773,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_put_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_put_sent{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1923,9 +1781,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_multi_put_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_multi_put_sent{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1933,9 +1789,7 @@
           "refId": "F"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_get_version_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_get_version_sent{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1943,9 +1797,7 @@
           "refId": "G"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_get_peerlist_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_get_peerlist_sent{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1953,9 +1805,7 @@
           "refId": "H"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_pull_query_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_pull_query_sent{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1963,9 +1813,7 @@
           "refId": "I"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_push_query_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_push_query_sent{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1973,9 +1821,7 @@
           "refId": "J"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_version_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_version_sent{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1983,9 +1829,7 @@
           "refId": "K"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_ping_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_ping_sent{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -1993,9 +1837,7 @@
           "refId": "L"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_pong_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_pong_sent{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -2003,9 +1845,7 @@
           "refId": "M"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_get_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_get_sent{job=\"avalanchego\"}[1m])",
           "interval": "",
@@ -2013,9 +1853,7 @@
           "refId": "N"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_chits_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_chits_sent{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -2024,9 +1862,7 @@
           "refId": "O"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_app_gossip_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_app_gossip_sent{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -2035,9 +1871,7 @@
           "refId": "P"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_app_request_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_app_request_sent{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -2046,9 +1880,7 @@
           "refId": "Q"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "increase(avalanche_network_app_response_sent_bytes{job=\"avalanchego\"}[1m])/increase(avalanche_network_app_response_sent{job=\"avalanchego\"}[1m])",
           "hide": false,
@@ -2223,9 +2055,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of messages that are queued to be sent to peers",
       "fieldConfig": {
         "defaults": {
@@ -2312,9 +2142,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Amount of the stake in AVAX that is benched (ignored) because the nodes are unhealthy",
       "fieldConfig": {
         "defaults": {
@@ -2418,9 +2246,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -2433,9 +2259,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of messages waiting to acquire bytes from the inbound message throttler.",
       "fieldConfig": {
         "defaults": {
@@ -2522,9 +2346,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of bytes left in the validator byte allocation of the inbound message throttler",
       "fieldConfig": {
         "defaults": {
@@ -2613,9 +2435,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "The amount of time, on average, that we wait to acquire bytes from the throttler before reading a message.",
       "fieldConfig": {
         "defaults": {
@@ -2699,9 +2519,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "The amount of time, on average, that we wait to acquire from the throttler before reading a message.",
       "fieldConfig": {
         "defaults": {
@@ -2785,9 +2603,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of messages that are currently being handled and haven't yet returned their bytes to the inbound message throttler.",
       "fieldConfig": {
         "defaults": {
@@ -2874,9 +2690,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of messages waiting to acquire from the inbound message buffer throttler.",
       "fieldConfig": {
         "defaults": {
@@ -2962,9 +2776,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of bytes left in the at-large byte allocation of the inbound message throttler",
       "fieldConfig": {
         "defaults": {
@@ -3052,9 +2864,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of messages waiting to acquire bytes from the inbound bandwidth throttler.",
       "fieldConfig": {
         "defaults": {
@@ -3142,9 +2952,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3157,9 +2965,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of bytes left in the at-large byte allocation of the outbound message throttler",
       "fieldConfig": {
         "defaults": {
@@ -3247,9 +3053,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of bytes left in the validator byte allocation of the outbound message throttler",
       "fieldConfig": {
         "defaults": {
@@ -3334,9 +3138,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3349,9 +3151,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "From all chains",
       "fieldConfig": {
         "defaults": {
@@ -3555,9 +3355,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of messages that could not be parsed because they were of unknown type or invalidly formatted.",
       "fieldConfig": {
         "defaults": {
@@ -3639,9 +3437,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of inbound messages dropped (not processed) due to expiration in last minute.",
       "fieldConfig": {
         "defaults": {
@@ -3727,9 +3523,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of outbound messages dropped (not sent) due to rate-limiting in the last minute",
       "fieldConfig": {
         "defaults": {
@@ -3811,9 +3605,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Number of inbound connections dropped due to inbound connection rate-limiting",
       "fieldConfig": {
         "defaults": {
@@ -3896,9 +3688,7 @@
     },
     {
       "collapsed": false,
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3911,9 +3701,7 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -4046,9 +3834,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -4181,9 +3967,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Rate at which we save bytes (don't send/receive them over the network) by compressing messages/receiving compressed messages.",
       "fieldConfig": {
         "defaults": {

--- a/grafana/dashboards/p_chain.json
+++ b/grafana/dashboards/p_chain.json
@@ -1252,7 +1252,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1422,7 +1422,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/subnets.json
+++ b/grafana/dashboards/subnets.json
@@ -112,9 +112,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "round(increase(avalanche_${subnet}_blks_accepted_count{job=\"avalanchego\"}[1m]))>0",
           "interval": "",
@@ -126,9 +124,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -219,9 +215,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "The average time between a block's issuance and acceptance by this node over the last 5 minutes.",
       "fieldConfig": {
         "defaults": {
@@ -307,9 +301,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "The average time between a block's issuance and rejection by this node over the last 5 minutes.",
       "fieldConfig": {
         "defaults": {
@@ -471,9 +463,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "avalanche_${subnet}_blks_processing{job=\"avalanchego\"}>0",
           "interval": "",
@@ -485,9 +475,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -571,9 +559,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Measures how much of each second is being spent handling different kinds of messages on the C-Chain.\nThe value for chits, for example, is the number of seconds spent handling chits messages per second, over the last 30 seconds.",
       "fieldConfig": {
         "defaults": {
@@ -770,9 +756,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Percentage of queries for which we receive chits on time.",
       "fieldConfig": {
         "defaults": {
@@ -865,9 +849,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Measures how long each kind of request on the C-Chain takes to handle.\nThe value for chits, for example, is how long, in seconds, it takes to handle a chits message.",
       "fieldConfig": {
         "defaults": {
@@ -1064,9 +1046,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "The total stake of validators currently \"benched\" due to poor query responsiveness. Queries to these validators will immediately timeout until they are removed from the \"bench.\"",
       "fieldConfig": {
         "defaults": {
@@ -1156,9 +1136,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Measures how many of each kind of message are received per second on the C-Chain.",
       "fieldConfig": {
         "defaults": {
@@ -1688,9 +1666,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/dashboards/x_chain.json
+++ b/grafana/dashboards/x_chain.json
@@ -37,9 +37,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-             "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -121,9 +119,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "round(increase(avalanche_X_blks_accepted_count{job=\"avalanchego\"}[1m]))>0",
@@ -133,9 +129,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "round(increase(avalanche_X_blks_rejected_count{job=\"avalanchego\"}[1m]))>0",
@@ -150,9 +144,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "The average time between a block's issuance and acceptance by this node over the last 5 minutes.",
       "fieldConfig": {
         "defaults": {
@@ -230,9 +222,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "rate(avalanche_X_blks_accepted_sum{job=\"avalanchego\"}[5m]) / rate(avalanche_X_blks_accepted_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -241,9 +231,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "expr": "rate(avalanche_X_blks_rejected_sum{job=\"avalanchego\"}[5m]) / rate(avalanche_X_blks_rejected_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -257,9 +245,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -337,9 +323,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "avalanche_X_blks_processing{job=\"avalanchego\"}>0",
@@ -354,9 +338,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Percentage of queries sent that we receive a response to. (Average over the last 5 minutes.)",
       "fieldConfig": {
         "defaults": {
@@ -438,9 +420,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "(increase(avalanche_X_handler_chits_count{job=\"avalanchego\"}[5m]) + 1) / (increase(avalanche_X_handler_chits_count{job=\"avalanchego\"}[5m]) + increase(avalanche_X_handler_query_failed_count{job=\"avalanchego\"}[5m]) + 1)",
           "instant": false,
@@ -453,9 +433,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Measures how much of each second is being spent handling different kinds of messages on the X-Chain.\nThe value for chits, for example, is the number of seconds spent handling chits messages per second.",
       "fieldConfig": {
         "defaults": {
@@ -535,9 +513,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_pull_query_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -545,9 +521,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_push_query_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -555,9 +529,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_chits_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -565,9 +537,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_accepted_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -575,9 +545,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_get_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -585,9 +553,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_put_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -595,9 +561,7 @@
           "refId": "F"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_multiput_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -605,9 +569,7 @@
           "refId": "G"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_get_ancestors_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -615,9 +577,7 @@
           "refId": "H"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_get_failed_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -625,9 +585,7 @@
           "refId": "I"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_query_failed_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -635,9 +593,7 @@
           "refId": "J"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_get_accepted_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -645,9 +601,7 @@
           "refId": "K"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_get_ancestors_failed_sum{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -655,9 +609,7 @@
           "refId": "L"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_app_request_sum{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -666,9 +618,7 @@
           "refId": "M"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_app_request_failed_sum{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -677,9 +627,7 @@
           "refId": "N"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_app_response_sum{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -688,9 +636,7 @@
           "refId": "O"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_app_gossip_sum{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -703,9 +649,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Measures how long each kind of request on the X-Chain takes to handle.\nThe value for chits, for example, is how long, in seconds, it takes to handle a chits message.",
       "fieldConfig": {
         "defaults": {
@@ -785,9 +729,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_pull_query_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_pull_query_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -795,9 +737,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_push_query_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_push_query_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -805,9 +745,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_chits_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_chits_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -815,9 +753,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_accepted_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_accepted_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -825,9 +761,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_get_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_get_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -835,9 +769,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_put_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_put_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -845,9 +777,7 @@
           "refId": "F"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_multiput_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_multi_put_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -855,9 +785,7 @@
           "refId": "G"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_get_ancestors_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_get_ancestors_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -865,9 +793,7 @@
           "refId": "H"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_get_failed_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_get_failed_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -875,9 +801,7 @@
           "refId": "I"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_query_failed_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_query_failed_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -885,9 +809,7 @@
           "refId": "J"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_get_accepted_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_get_accepted_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -895,9 +817,7 @@
           "refId": "K"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_get_ancestors_failed_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_get_ancestors_failed_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -905,9 +825,7 @@
           "refId": "L"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_app_request_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_app_request_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -916,9 +834,7 @@
           "refId": "M"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_app_request_failed_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_app_request_failed_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -927,9 +843,7 @@
           "refId": "N"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_app_gossip_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_app_gossip_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -938,9 +852,7 @@
           "refId": "O"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_app_response_sum{job=\"avalanchego\"}[5m])/rate(avalanche_X_handler_app_response_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -953,9 +865,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "The total stake of validators currently \"benched\" due to poor query responsiveness. Queries to these validators will immediately timeout until they are removed from the \"bench.\"",
       "fieldConfig": {
         "defaults": {
@@ -1037,9 +947,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "avg_over_time(avalanche_X_benchlist_benched_weight{job=\"avalanchego\"}[15m]) / 10^9",
           "interval": "",
@@ -1051,9 +959,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "Measures how many of each kind of message are received per second on the X-Chain.",
       "fieldConfig": {
         "defaults": {
@@ -1133,9 +1039,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_pull_query_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1143,9 +1047,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_push_query_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1153,9 +1055,7 @@
           "refId": "B"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_chits_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1163,9 +1063,7 @@
           "refId": "C"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_accepted_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1173,9 +1071,7 @@
           "refId": "D"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_get_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1183,9 +1079,7 @@
           "refId": "E"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_put_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1193,9 +1087,7 @@
           "refId": "F"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_multi_put_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1203,9 +1095,7 @@
           "refId": "G"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_get_ancestors_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1213,9 +1103,7 @@
           "refId": "H"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_get_failed_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1223,9 +1111,7 @@
           "refId": "I"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_query_failed_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1233,9 +1119,7 @@
           "refId": "J"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_get_accepted_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1243,9 +1127,7 @@
           "refId": "K"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_get_ancestors_failed_count{job=\"avalanchego\"}[5m])",
           "interval": "",
@@ -1253,9 +1135,7 @@
           "refId": "L"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_chits_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -1264,9 +1144,7 @@
           "refId": "M"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_app_request_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -1275,9 +1153,7 @@
           "refId": "N"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_app_request_failed_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -1286,9 +1162,7 @@
           "refId": "O"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_app_response_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -1297,9 +1171,7 @@
           "refId": "P"
         },
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "exemplar": true,
           "expr": "rate(avalanche_X_handler_app_gossip_count{job=\"avalanchego\"}[5m])",
           "hide": false,
@@ -1312,9 +1184,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1388,9 +1258,7 @@
       },
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "increase(avalanche_X_vm_avalanche_utxo_cache_hit[5m])/(increase(avalanche_X_vm_avalanche_utxo_cache_hit[5m])+increase(avalanche_X_vm_avalanche_utxo_cache_miss[5m]))",
@@ -1404,9 +1272,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1486,9 +1352,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "editorMode": "code",
           "exemplar": true,
           "expr": "avalanche_X_handler_unprocessed_msgs_len",
@@ -1502,9 +1366,7 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus"
-      },
+      "datasource": "Prometheus",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -1585,9 +1447,7 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "datasource": {
-             "type": "prometheus"
-          },
+          "datasource": "Prometheus",
           "expr": "increase(avalanche_X_handler_expired[1m])",
           "interval": "",
           "legendFormat": "Expired",


### PR DESCRIPTION
Most of the `datasource` fields are defined as:

```
"datasource": {
  "type": "prometheus"
},
```

This results a "random walk" in Grafana:

![image](https://github.com/ava-labs/avalanche-monitoring/assets/12017342/cfdcf868-1c54-4888-b441-a6b2c10b48b5)

It might be better defining the datasources with the name its given in [monitoring-installer.sh](https://github.com/ava-labs/avalanche-monitoring/blob/main/grafana/monitoring-installer.sh#L338):

```
"datasource": "Prometheus",
```

This PR aims at: 
- Fixing some `datasource` fields which have `null` as value
- Fixing some `datasource` fields with missing name