### PR TITLE
Update dashboards for use with temporary networks

### DIFF
--- a/grafana/dashboards/c_chain.json
+++ b/grafana/dashboards/c_chain.json
@@ -28,13 +28,15 @@
   "links": [
     {
       "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [
         "Avalanche"
       ],
       "type": "dashboards"
     }
   ],
-  "liveNow": false,
+  "liveNow": true,
   "panels": [
     {
       "datasource": {
@@ -125,7 +127,7 @@
           "exemplar": true,
           "expr": "round(increase(avalanche_snowman_blks_accepted_count{chain=\"C\", job=\"avalanchego\"}[1m]))>0",
           "interval": "",
-          "legendFormat": "Blocks",
+          "legendFormat": "Blocks {{node_id}}",
           "refId": "A"
         }
       ],
@@ -222,7 +224,7 @@
           "exemplar": true,
           "expr": "round(increase(avalanche_snowman_blks_rejected_count{chain=\"C\", job=\"avalanchego\"}[1m]))>0",
           "interval": "",
-          "legendFormat": "Blocks",
+          "legendFormat": "Blocks {{node_id}}",
           "range": true,
           "refId": "A"
         }
@@ -316,7 +318,7 @@
           },
           "expr": "rate(avalanche_snowman_blks_accepted_sum{chain=\"C\", job=\"avalanchego\"}[5m]) / rate(avalanche_snowman_blks_accepted_count{chain=\"C\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "Avg Acceptance Latency",
+          "legendFormat": "Avg Acceptance Latency {{node_id}}",
           "refId": "A"
         }
       ],
@@ -412,7 +414,7 @@
           },
           "expr": "rate(avalanche_snowman_blks_rejected_sum{chain=\"C\", job=\"avalanchego\"}[5m]) / rate(avalanche_snowman_blks_rejected_count{chain=\"C\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "Avg Rejection Latency",
+          "legendFormat": "Avg Rejection Latency {{node_id}}",
           "refId": "A"
         }
       ],
@@ -503,7 +505,7 @@
           "exemplar": true,
           "expr": "avalanche_snowman_blks_processing{chain=\"C\", job=\"avalanchego\"}>0",
           "interval": "",
-          "legendFormat": "Blocks",
+          "legendFormat": "Blocks {{node_id}}",
           "refId": "A"
         }
       ],
@@ -594,7 +596,7 @@
           "exemplar": true,
           "expr": "avalanche_snowman_polls{chain=\"C\"} > 0",
           "interval": "",
-          "legendFormat": "Polls",
+          "legendFormat": "Polls {{node_id}}",
           "refId": "A"
         }
       ],
@@ -673,7 +675,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
@@ -690,7 +692,7 @@
           "exemplar": true,
           "expr": "rate(avalanche_handler_message_handling_time{chain=\"C\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -883,7 +885,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
@@ -900,7 +902,7 @@
           "exemplar": true,
           "expr": "rate(avalanche_handler_message_handling_time{chain=\"C\", job=\"avalanchego\"}[5m])/rate(avalanche_handler_messages{chain=\"C\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -992,7 +994,7 @@
           "exemplar": true,
           "expr": "avalanche_handler_sync_unprocessed_msgs_count{chain=\"C\"}",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         },
         {
@@ -1094,7 +1096,7 @@
           "exemplar": true,
           "expr": "increase(avalanche_handler_expired{chain=\"C\", job=\"avalanchego\"}[1m]) or 0 * up",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1191,7 +1193,7 @@
           "exemplar": true,
           "expr": "avg_over_time(avalanche_benchlist_benched_weight{chain=\"C\", job=\"avalanchego\"}[15m]) / 10^9",
           "interval": "",
-          "legendFormat": "AVAX Benched",
+          "legendFormat": "AVAX Benched {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1270,7 +1272,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
@@ -1287,7 +1289,7 @@
           "exemplar": true,
           "expr": "rate(avalanche_handler_messages{chain=\"C\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1378,7 +1380,7 @@
           },
           "expr": "sum(increase(avalanche_evm_chain_state_bytes_to_id_cache_get_count{chain=\"C\", result=\"hit\"}[5m]) or 0 * up)",
           "interval": "",
-          "legendFormat": "Hits",
+          "legendFormat": "Hits {{node_id}}",
           "refId": "A",
           "hide": true
         },
@@ -1388,7 +1390,7 @@
           },
           "expr": "sum(increase(avalanche_evm_chain_state_bytes_to_id_cache_get_count{chain=\"C\"}[5m]) or 0 * up)",
           "interval": "",
-          "legendFormat": "Hits",
+          "legendFormat": "Calls {{node_id}}",
           "refId": "B",
           "hide": true
         },
@@ -1491,7 +1493,7 @@
           },
           "expr": "sum(increase(avalanche_evm_chain_state_decided_cache_get_count{chain=\"C\", result=\"hit\"}[5m]) or 0 * up)",
           "interval": "",
-          "legendFormat": "Hits",
+          "legendFormat": "Hits {{node_id}}",
           "refId": "A",
           "hide": true
         },
@@ -1501,7 +1503,7 @@
           },
           "expr": "sum(increase(avalanche_evm_chain_state_decided_cache_get_count{chain=\"C\"}[5m]) or 0 * up)",
           "interval": "",
-          "legendFormat": "Calls",
+          "legendFormat": "Calls {{node_id}}",
           "refId": "B",
           "hide": true
         },
@@ -1604,7 +1606,7 @@
           },
           "expr": "sum(increase(avalanche_evm_chain_state_missing_cache_get_count{chain=\"C\", result=\"hit\"}[5m]) or 0 * up)",
           "interval": "",
-          "legendFormat": "Hits",
+          "legendFormat": "Hits {{node_id}}",
           "refId": "A",
           "hide": true
         },
@@ -1614,7 +1616,7 @@
           },
           "expr": "sum(increase(avalanche_evm_chain_state_missing_cache_get_count{chain=\"C\"}[5m]) or 0 * up)",
           "interval": "",
-          "legendFormat": "Calls",
+          "legendFormat": "Calls {{node_id}}",
           "refId": "B",
           "hide": true
         },
@@ -1716,7 +1718,7 @@
           },
           "expr": "sum(increase(avalanche_evm_chain_state_unverified_cache_get_count{chain=\"C\", result=\"hit\"}[5m]) or 0 * up)",
           "interval": "",
-          "legendFormat": "Hits",
+          "legendFormat": "Hits {{node_id}}",
           "refId": "A",
           "hide": true
         },
@@ -1726,7 +1728,7 @@
           },
           "expr": "sum(increase(avalanche_evm_chain_state_unverified_cache_get_count{chain=\"C\"}[5m]) or 0 * up)",
           "interval": "",
-          "legendFormat": "Calls",
+          "legendFormat": "Calls {{node_id}}",
           "refId": "B",
           "hide": true
         },
@@ -1752,7 +1754,19 @@
     "Avalanche"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "filters": [],
+        "hide": 0,
+        "label": "Filter",
+        "name": "filter",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/grafana/dashboards/database.json
+++ b/grafana/dashboards/database.json
@@ -19,15 +19,20 @@
   "links": [
     {
       "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [
         "Avalanche"
       ],
       "type": "dashboards"
     }
   ],
+  "liveNow": true,
   "panels": [
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "Database read rate. Note that these reads may be from caches and not from disk.",
       "fieldConfig": {
         "defaults": {
@@ -108,7 +113,7 @@
           },
           "expr": "sum(rate(avalanche_meterdb_size{chain=\"all\", method=~\"has|get|iterator_next\"}[5m]))",
           "interval": "",
-          "legendFormat": "Bytes Read",
+          "legendFormat": "Bytes Read {{node_id}}",
           "refId": "A"
         }
       ],
@@ -118,7 +123,9 @@
       "type": "timeseries"
     },
     {
-      "datasource": null,
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "Database write rate.",
       "fieldConfig": {
         "defaults": {
@@ -199,7 +206,7 @@
           },
           "expr": "sum(rate(avalanche_meterdb_size{chain=\"all\", method=~\"put|delete|batch_write\"}[5m]))",
           "interval": "",
-          "legendFormat": "Bytes Written",
+          "legendFormat": "Bytes Written {{node_id}}",
           "refId": "A"
         }
       ],
@@ -209,7 +216,9 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "Measures how many of each database operation is performed each second across all chains",
       "fieldConfig": {
         "defaults": {
@@ -276,7 +285,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "bottom"
         },
         "tooltip": {
           "mode": "single"
@@ -287,7 +296,7 @@
         {
           "expr": "rate(avalanche_meterdb_calls{chain=\"all\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ method }}",
+          "legendFormat": "{{ method }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -297,7 +306,9 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "Measures how long each database operation is taking on average",
       "fieldConfig": {
         "defaults": {
@@ -365,7 +376,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "bottom"
         },
         "tooltip": {
           "mode": "single"
@@ -376,7 +387,7 @@
         {
           "expr": "increase(avalanche_meterdb_duration{chain=\"all\", job=\"avalanchego\"}[5m])/increase(avalanche_meterdb_calls{chain=\"all\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ method }}",
+          "legendFormat": "{{ method }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -386,7 +397,9 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "Measures how many of each database operation is performed each second on X-Chain",
       "fieldConfig": {
         "defaults": {
@@ -453,7 +466,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "bottom"
         },
         "tooltip": {
           "mode": "single"
@@ -464,7 +477,7 @@
         {
           "expr": "rate(avalanche_meterdb_calls{chain=\"X\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ method }}",
+          "legendFormat": "{{ method }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -474,7 +487,9 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "Measures how long each database operation is taking on average on X-Chain",
       "fieldConfig": {
         "defaults": {
@@ -542,7 +557,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "bottom"
         },
         "tooltip": {
           "mode": "single"
@@ -553,7 +568,7 @@
         {
           "expr": "increase(avalanche_meterdb_duration{chain=\"X\", job=\"avalanchego\"}[5m])/increase(avalanche_meterdb_calls{chain=\"X\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ method }}",
+          "legendFormat": "{{ method }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -563,7 +578,9 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "Measures how many of each database operation is performed each second on P-Chain",
       "fieldConfig": {
         "defaults": {
@@ -630,7 +647,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "bottom"
         },
         "tooltip": {
           "mode": "single"
@@ -641,7 +658,7 @@
         {
           "expr": "rate(avalanche_meterdb_calls{chain=\"P\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ method }}",
+          "legendFormat": "{{ method }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -651,7 +668,9 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "Measures how long each database operation is taking on average on P-Chain",
       "fieldConfig": {
         "defaults": {
@@ -719,7 +738,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "bottom"
         },
         "tooltip": {
           "mode": "single"
@@ -730,7 +749,7 @@
         {
           "expr": "increase(avalanche_meterdb_duration{chain=\"P\", job=\"avalanchego\"}[5m])/increase(avalanche_meterdb_calls{chain=\"P\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ method }}",
+          "legendFormat": "{{ method }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -740,7 +759,9 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "Measures how many of each database operation is performed each second across all chains",
       "fieldConfig": {
         "defaults": {
@@ -807,7 +828,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "bottom"
         },
         "tooltip": {
           "mode": "single"
@@ -818,7 +839,7 @@
         {
           "expr": "rate(avalanche_meterdb_calls{chain=\"C\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ method }}",
+          "legendFormat": "{{ method }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -828,7 +849,9 @@
       "type": "timeseries"
     },
     {
-      "datasource": "Prometheus",
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "Measures how long each database operation is taking on average on C-Chain",
       "fieldConfig": {
         "defaults": {
@@ -896,7 +919,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "bottom"
         },
         "tooltip": {
           "mode": "single"
@@ -907,7 +930,7 @@
         {
           "expr": "increase(avalanche_meterdb_duration{chain=\"C\", job=\"avalanchego\"}[5m])/increase(avalanche_meterdb_calls{chain=\"C\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ method }}",
+          "legendFormat": "{{ method }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -924,7 +947,19 @@
     "Avalanche"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "filters": [],
+        "hide": 0,
+        "label": "Filter",
+        "name": "filter",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      }
+    ]
   },
   "time": {
     "from": "now-1h",

--- a/grafana/dashboards/logs.json
+++ b/grafana/dashboards/logs.json
@@ -1,0 +1,211 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Loki dashboard with quick search and timeline.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 13186,
+  "graphTooltip": 0,
+  "id": 12,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "Avalanche"
+      ],
+      "targetBlank": false,
+      "title": "",
+      "tooltip": "",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "loki"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "10.4.0",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki"
+          },
+          "editorMode": "code",
+          "expr": "sum(count_over_time({network_uuid=~\".+\"} |~ \"$search\"[$__interval]))",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Timeline",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": false
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "datasource": {
+        "type": "loki"
+      },
+      "gridPos": {
+        "h": 25,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 2,
+      "maxDataPoints": "",
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki"
+          },
+          "editorMode": "code",
+          "expr": "{network_uuid=~\".+\"} |~ \"$search\"",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs",
+      "type": "logs"
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [
+    "Avalanche"
+  ],
+  "templating": {
+    "list": [
+      {
+        "hide": 0,
+        "name": "search",
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "filters": [],
+        "hide": 0,
+        "label": "Filter",
+        "name": "filter",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      }
+    ]
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Logs",
+  "uid": "liz0yRCZz",
+  "version": 6,
+  "weekStart": ""
+}

--- a/grafana/dashboards/machine.json
+++ b/grafana/dashboards/machine.json
@@ -29,13 +29,15 @@
   "links": [
     {
       "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [
         "Avalanche"
       ],
       "type": "dashboards"
     }
   ],
-  "liveNow": false,
+  "liveNow": true,
   "panels": [
     {
       "alert": {
@@ -725,7 +727,19 @@
     "Avalanche"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "filters": [],
+        "hide": 0,
+        "label": "Filter",
+        "name": "filter",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      }
+    ]
   },
   "time": {
     "from": "now-1h",

--- a/grafana/dashboards/main.json
+++ b/grafana/dashboards/main.json
@@ -29,13 +29,15 @@
   "links": [
     {
       "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [
         "Avalanche"
       ],
       "type": "dashboards"
     }
   ],
-  "liveNow": false,
+  "liveNow": true,
   "panels": [
     {
       "datasource": {
@@ -111,7 +113,7 @@
           "exemplar": true,
           "expr": "avalanche_network_node_uptime_weighted_average{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{node_id}}",
           "refId": "A"
         }
       ],
@@ -188,7 +190,7 @@
           "exemplar": true,
           "expr": "avalanche_network_node_uptime_rewarding_stake{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Rewarding stake",
+          "legendFormat": "Rewarding stake {{node_id}}",
           "refId": "A"
         }
       ],
@@ -292,7 +294,7 @@
           "exemplar": true,
           "expr": "round(increase(avalanche_snowman_blks_accepted_count{chain=\"X\", job=\"avalanchego\"}[1m]))>0",
           "interval": "",
-          "legendFormat": "Accepted",
+          "legendFormat": "Accepted {{node_id}}",
           "range": true,
           "refId": "A"
         },
@@ -305,7 +307,7 @@
           "expr": "round(increase(avalanche_snowman_blks_rejected_count{chain=\"X\", job=\"avalanchego\"}[1m]))>0",
           "hide": false,
           "interval": "",
-          "legendFormat": "Rejected",
+          "legendFormat": "Rejected {{node_id}}",
           "range": true,
           "refId": "B"
         }
@@ -368,7 +370,7 @@
           "exemplar": true,
           "expr": "round(increase(avalanche_snowman_blks_built{chain=\"X\", job=\"avalanchego\"}[1d]))",
           "interval": "",
-          "legendFormat": "Proposed X blocks",
+          "legendFormat": "Proposed X blocks {{node_id}}",
           "range": true,
           "refId": "A"
         }
@@ -471,7 +473,7 @@
           "exemplar": true,
           "expr": "round(increase(avalanche_snowman_blks_accepted_count{chain=\"P\", job=\"avalanchego\"}[1m]))>0",
           "interval": "",
-          "legendFormat": "Accepted",
+          "legendFormat": "Accepted {{node_id}}",
           "refId": "A"
         },
         {
@@ -482,7 +484,7 @@
           "expr": "round(increase(avalanche_snowman_blks_rejected_count{chain=\"P\", job=\"avalanchego\"}[1m]))>0",
           "hide": false,
           "interval": "",
-          "legendFormat": "Rejected",
+          "legendFormat": "Rejected {{node_id}}",
           "refId": "B"
         }
       ],
@@ -543,7 +545,7 @@
           "exemplar": true,
           "expr": "round(increase(avalanche_snowman_blks_built{chain=\"P\", job=\"avalanchego\"}[1d]))",
           "interval": "",
-          "legendFormat": "Proposed P blocks",
+          "legendFormat": "Proposed P blocks {{node_id}}",
           "refId": "A"
         }
       ],
@@ -618,7 +620,7 @@
           },
           "expr": "(1 - avg(irate(node_cpu_seconds_total{job=~\"avalanchego-machine\", mode=\"idle\"}[1m])) by (instance)) * 100",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{node_id}}",
           "refId": "A"
         }
       ],
@@ -673,6 +675,8 @@
       },
       "id": 2,
       "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -693,7 +697,7 @@
           },
           "expr": "max(((node_filesystem_size_bytes{job=~\"avalanchego-machine\", fstype=~\"ext4|vfat\"} - node_filesystem_free_bytes{job=~\"avalanchego-machine\", fstype=~\"ext4|vfat\"}) / node_filesystem_size_bytes{job=~\"avalanchego-machine\", fstype=~\"ext4|vfat\"}) * 100) by (instance)",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{node_id}}",
           "refId": "A"
         }
       ],
@@ -762,7 +766,7 @@
           "editorMode": "code",
           "expr": "avalanche_health_health_checks_failing{job=\"avalanchego\",tag=\"all\"}",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{node_id}}",
           "range": true,
           "refId": "A"
         }
@@ -839,7 +843,7 @@
           "exemplar": true,
           "expr": "avalanche_requests_average_latency",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{node_id}}",
           "refId": "A"
         }
       ],
@@ -901,7 +905,7 @@
           "exemplar": true,
           "expr": "avalanche_platformvm_total_staked{chain=\"P\", job=\"avalanchego\"}/1000000000",
           "interval": "",
-          "legendFormat": "AVAX",
+          "legendFormat": "AVAX {{node_id}}",
           "refId": "A"
         }
       ],
@@ -973,7 +977,7 @@
           "editorMode": "code",
           "expr": "avalanche_stake_percent_connected{chain=\"P\", job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "{{node_id}}",
           "range": true,
           "refId": "A"
         }
@@ -1074,7 +1078,7 @@
           },
           "expr": "avalanche_network_peers{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Peers",
+          "legendFormat": "Peers {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1176,7 +1180,7 @@
           "exemplar": true,
           "expr": "round(increase(avalanche_snowman_blks_accepted_count{chain=\"C\", job=\"avalanchego\"}[1m]))>0",
           "interval": "",
-          "legendFormat": "Accepted",
+          "legendFormat": "Accepted {{node_id}}",
           "refId": "A"
         },
         {
@@ -1187,7 +1191,7 @@
           "expr": "round(increase(avalanche_snowman_blks_rejected_count{chain=\"C\", job=\"avalanchego\"}[1m]))>0",
           "hide": false,
           "interval": "",
-          "legendFormat": "Rejected",
+          "legendFormat": "Rejected {{node_id}}",
           "refId": "B"
         }
       ],
@@ -1252,7 +1256,7 @@
           "exemplar": true,
           "expr": "round(increase(avalanche_snowman_blks_built{chain=\"C\", job=\"avalanchego\"}[1d]))",
           "interval": "",
-          "legendFormat": "Built C blocks",
+          "legendFormat": "Built C blocks {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1313,7 +1317,7 @@
           },
           "expr": "round(increase(avalanche_snowman_blks_accepted_count{job=\"avalanchego\"}[1m]))",
           "interval": "",
-          "legendFormat": "{{ chain }} Chain",
+          "legendFormat": "{{ chain }} Chain {{node_id}}",
           "range": true,
           "refId": "A"
         }
@@ -1383,7 +1387,7 @@
           },
           "expr": "avalanche_snowman_blks_processing{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "{{ chain }} Chain",
+          "legendFormat": "{{ chain }} Chain {{node_id}}",
           "range": true,
           "refId": "A"
         }
@@ -1444,7 +1448,7 @@
           },
           "expr": "avalanche_benchlist_benched_num{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "{{ chain }} Chain",
+          "legendFormat": "{{ chain }} Chain {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1516,7 +1520,7 @@
           "expr": "sum by (chain)(increase(avalanche_handler_messages{op=\"chits\", job=\"avalanchego\"}[1m]))",
           "hide": true,
           "interval": "",
-          "legendFormat": "{{ chain }} Chain",
+          "legendFormat": "{{ chain }} Chain {{node_id}}",
           "refId": "A"
         },
         {
@@ -1526,7 +1530,7 @@
           "expr": "sum by (chain)(increase(avalanche_handler_messages{op=\"query_failed\", job=\"avalanchego\"}[1m]))",
           "hide": true,
           "interval": "",
-          "legendFormat": "{{ chain }} Chain",
+          "legendFormat": "{{ chain }} Chain {{node_id}}",
           "refId": "B"
         },
         {
@@ -1612,7 +1616,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
@@ -1628,7 +1632,7 @@
           },
           "expr": "increase(avalanche_meterdb_duration{chain=\"all\", job=\"avalanchego\"}[5m])/increase(avalanche_meterdb_calls{chain=\"all\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ method }}",
+          "legendFormat": "{{ method }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1643,7 +1647,19 @@
     "Avalanche"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "filters": [],
+        "hide": 0,
+        "label": "Filter",
+        "name": "filter",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/grafana/dashboards/network.json
+++ b/grafana/dashboards/network.json
@@ -28,13 +28,15 @@
   "links": [
     {
       "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [
         "Avalanche"
       ],
       "type": "dashboards"
     }
   ],
-  "liveNow": false,
+  "liveNow": true,
   "panels": [
     {
       "collapsed": false,
@@ -156,7 +158,7 @@
           "exemplar": true,
           "expr": "avalanche_network_node_uptime_weighted_average{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Uptime average",
+          "legendFormat": "Uptime average {{node_id}}",
           "refId": "A"
         }
       ],
@@ -263,7 +265,7 @@
           "exemplar": true,
           "expr": "avalanche_network_node_uptime_rewarding_stake{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Rewarding stake",
+          "legendFormat": "Rewarding stake {{node_id}}",
           "refId": "A"
         }
       ],
@@ -391,7 +393,7 @@
           "expr": "avalanche_network_peers{job=\"avalanchego\"}",
           "format": "time_series",
           "interval": "",
-          "legendFormat": "Peers connected",
+          "legendFormat": "Peers connected {{node_id}}",
           "refId": "B"
         }
       ],
@@ -482,17 +484,17 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avalanche_requests_current_timeout",
+          "expr": "avalanche_requests_current_timeout{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Timeout",
+          "legendFormat": "Timeout {{node_id}}",
           "refId": "A"
         },
         {
           "exemplar": true,
-          "expr": "avalanche_requests_average_latency",
+          "expr": "avalanche_requests_average_latency{job=\"avalanchego\"}",
           "hide": false,
           "interval": "",
-          "legendFormat": "Response Time",
+          "legendFormat": "Response Time {{node_id}}",
           "refId": "B"
         }
       ],
@@ -581,9 +583,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avalanche_requests_outstanding",
+          "expr": "avalanche_requests_outstanding{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Outstanding Requests",
+          "legendFormat": "Outstanding Requests {{node_id}}",
           "refId": "A"
         }
       ],
@@ -662,7 +664,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true,
           "sortBy": "Mean",
           "sortDesc": true
@@ -677,7 +679,7 @@
         {
           "expr": "rate(avalanche_network_msgs{io=\"received\", job=\"avalanchego\"}[1m])",
           "interval": "",
-          "legendFormat": "{{ op }} compressed={{ compressed }}",
+          "legendFormat": "{{ op }} compressed={{ compressed }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -756,7 +758,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true,
           "sortBy": "Mean",
           "sortDesc": true
@@ -771,7 +773,7 @@
         {
           "expr": "rate(avalanche_network_msgs{io=\"sent\", job=\"avalanchego\"}[1m])",
           "interval": "",
-          "legendFormat": "{{ op }} compressed={{ compressed }}",
+          "legendFormat": "{{ op }} compressed={{ compressed }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -848,7 +850,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true,
           "sortBy": "Mean",
           "sortDesc": true
@@ -866,7 +868,7 @@
           },
           "expr": "rate(avalanche_network_msgs_bytes{io=\"received\", job=\"avalanchego\"}[1m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -943,7 +945,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true,
           "sortBy": "Mean",
           "sortDesc": true
@@ -961,7 +963,7 @@
           },
           "expr": "rate(avalanche_network_msgs_bytes{io=\"sent\", job=\"avalanchego\"}[1m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1038,7 +1040,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true,
           "sortBy": "Mean",
           "sortDesc": true
@@ -1056,7 +1058,7 @@
           },
           "expr": "increase(avalanche_network_msgs_bytes{io=\"received\", job=\"avalanchego\"}[1m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A",
           "hide": true
         },
@@ -1066,7 +1068,7 @@
           },
           "expr": "increase(avalanche_network_msgs{io=\"received\", job=\"avalanchego\"}[1m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "B",
           "hide": true
         },
@@ -1154,7 +1156,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true,
           "sortBy": "Mean",
           "sortDesc": true
@@ -1172,7 +1174,7 @@
           },
           "expr": "increase(avalanche_network_msgs_bytes{io=\"sent\", job=\"avalanchego\"}[1m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A",
           "hide": true
         },
@@ -1182,7 +1184,7 @@
           },
           "expr": "increase(avalanche_network_msgs{io=\"sent\", job=\"avalanchego\"}[1m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "B",
           "hide": true
         },
@@ -1286,7 +1288,7 @@
           },
           "expr": "sum(increase(avalanche_network_msgs{io=\"sent\", op=~\"pull_query|push_query\", job=\"avalanchego\"}[5m]))",
           "interval": "",
-          "legendFormat": "Messages",
+          "legendFormat": "Messages {{node_id}}",
           "refId": "A",
           "hide": true
         },
@@ -1296,7 +1298,7 @@
           },
           "expr": "sum(increase(avalanche_snowman_blks_accepted_count{chain=~\"C|P|X\", job=\"avalanchego\"}[5m]))",
           "interval": "",
-          "legendFormat": "Messages",
+          "legendFormat": "Messages {{node_id}}",
           "refId": "B",
           "hide": true
         },
@@ -1397,9 +1399,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avalanche_network_throttler_outbound_awaiting_release",
+          "expr": "avalanche_network_throttler_outbound_awaiting_release{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Messages",
+          "legendFormat": "Messages {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1480,7 +1482,7 @@
             "last"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
@@ -1493,7 +1495,7 @@
         {
           "expr": "avalanche_benchlist_benched_weight/1000000000",
           "interval": "",
-          "legendFormat": "{{ chain }}",
+          "legendFormat": "{{ chain }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1599,9 +1601,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avalanche_network_byte_throttler_inbound_awaiting_acquire",
+          "expr": "avalanche_network_byte_throttler_inbound_awaiting_acquire{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Messages Awaiting Acquire",
+          "legendFormat": "Messages Awaiting Acquire {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1693,9 +1695,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avalanche_network_byte_throttler_inbound_remaining_validator_bytes",
+          "expr": "avalanche_network_byte_throttler_inbound_remaining_validator_bytes{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Bytes Remaining",
+          "legendFormat": "Bytes Remaining {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1782,9 +1784,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "increase(avalanche_network_byte_throttler_inbound_acquire_latency_sum[2m])/increase(avalanche_network_byte_throttler_inbound_acquire_latency_count[2m])",
+          "expr": "increase(avalanche_network_byte_throttler_inbound_acquire_latency_sum{job=\"avalanchego\"}[2m])/increase(avalanche_network_byte_throttler_inbound_acquire_latency_count{job=\"avalanchego\"}[2m])",
           "interval": "",
-          "legendFormat": "Acquire",
+          "legendFormat": "Acquire {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1871,9 +1873,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "increase(avalanche_network_buffer_throttler_inbound_acquire_latency_sum[2m])/increase(avalanche_network_buffer_throttler_inbound_acquire_latency_count[2m])",
+          "expr": "increase(avalanche_network_buffer_throttler_inbound_acquire_latency_sum{job=\"avalanchego\"}[2m])/increase(avalanche_network_buffer_throttler_inbound_acquire_latency_count{job=\"avalanchego\"}[2m])",
           "interval": "",
-          "legendFormat": "Acquire",
+          "legendFormat": "Acquire {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1963,9 +1965,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avalanche_network_byte_throttler_inbound_awaiting_release",
+          "expr": "avalanche_network_byte_throttler_inbound_awaiting_release{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Messages Awaiting Release",
+          "legendFormat": "Messages Awaiting Release {{node_id}}",
           "refId": "A"
         }
       ],
@@ -2054,9 +2056,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avalanche_network_buffer_throttler_inbound_awaiting_acquire",
+          "expr": "avalanche_network_buffer_throttler_inbound_awaiting_acquire{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Messages Awaiting",
+          "legendFormat": "Messages Awaiting {{node_id}}",
           "refId": "A"
         }
       ],
@@ -2147,9 +2149,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avalanche_network_byte_throttler_inbound_remaining_at_large_bytes",
+          "expr": "avalanche_network_byte_throttler_inbound_remaining_at_large_bytes{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Remaining Bytes",
+          "legendFormat": "Remaining Bytes {{node_id}}",
           "refId": "A"
         }
       ],
@@ -2239,9 +2241,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avalanche_network_bandwidth_throttler_inbound_awaiting_acquire",
+          "expr": "avalanche_network_bandwidth_throttler_inbound_awaiting_acquire{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Messages Awaiting Acquire",
+          "legendFormat": "Messages Awaiting Acquire {{node_id}}",
           "refId": "A"
         }
       ],
@@ -2348,9 +2350,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avalanche_network_throttler_outbound_remaining_at_large_bytes",
+          "expr": "avalanche_network_throttler_outbound_remaining_at_large_bytes{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Bytes Remaining",
+          "legendFormat": "Bytes Remaining {{node_id}}",
           "refId": "A"
         }
       ],
@@ -2437,9 +2439,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avalanche_network_throttler_outbound_remaining_validator_bytes",
+          "expr": "avalanche_network_throttler_outbound_remaining_validator_bytes{job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Bytes Remaining",
+          "legendFormat": "Bytes Remaining {{node_id}}",
           "refId": "A"
         }
       ],
@@ -2534,7 +2536,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
@@ -2547,7 +2549,7 @@
         {
           "expr": "rate(avalanche_network_msgs_failed_to_send{job=\"avalanchego\"}[1m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -2634,7 +2636,7 @@
           "exemplar": true,
           "expr": "increase(avalanche_network_msgs_failed_to_parse[1m])",
           "interval": "",
-          "legendFormat": "Failed to Parse",
+          "legendFormat": "Failed to Parse {{node_id}}",
           "refId": "A"
         }
       ],
@@ -2725,7 +2727,7 @@
           "exemplar": true,
           "expr": "sum(increase(avalanche_handler_expired[1m]) or 0 * up)",
           "interval": "",
-          "legendFormat": "Messages Dropped",
+          "legendFormat": "Messages Dropped {{node_id}}",
           "refId": "A"
         }
       ],
@@ -2810,9 +2812,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "increase(avalanche_network_throttler_outbound_acquire_failures[1m])",
+          "expr": "increase(avalanche_network_throttler_outbound_acquire_failures{job=\"avalanchego\"}[1m])",
           "interval": "",
-          "legendFormat": "Messages Dropped",
+          "legendFormat": "Messages Dropped {{node_id}}",
           "refId": "A"
         }
       ],
@@ -2897,9 +2899,9 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "increase(avalanche_network_inbound_conn_throttler_rate_limited[1m])",
+          "expr": "increase(avalanche_network_inbound_conn_throttler_rate_limited{job=\"avalanchego\"}[1m])",
           "interval": "",
-          "legendFormat": "Rate-Limited",
+          "legendFormat": "Rate-Limited {{node_id}}",
           "refId": "A"
         }
       ],
@@ -2994,7 +2996,7 @@
             "mean"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true,
           "sortBy": "Mean",
           "sortDesc": true
@@ -3014,7 +3016,7 @@
           "expr": "increase(avalanche_network_codec_compressed_duration{direction=\"compression\"}[5m])/increase(avalanche_network_codec_compressed_count{direction=\"compression\"}[5m])",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{ op }} {{ type }}",
+          "legendFormat": "{{ op }} {{ type }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -3093,7 +3095,7 @@
             "mean"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true,
           "sortBy": "Mean",
           "sortDesc": true
@@ -3110,7 +3112,7 @@
           },
           "expr": "increase(avalanche_network_codec_compressed_duration{direction=\"decompression\"}[5m])/increase(avalanche_network_codec_compressed_count{direction=\"decompression\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ op }} {{ type }}",
+          "legendFormat": "{{ op }} {{ type }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -3189,7 +3191,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
@@ -3201,7 +3203,7 @@
         {
           "expr": "rate(avalanche_network_msgs_bytes_saved[5m])",
           "interval": "",
-          "legendFormat": "{{ io }} {{ op }}",
+          "legendFormat": "{{ io }} {{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -3216,7 +3218,19 @@
     "Avalanche"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "filters": [],
+        "hide": 0,
+        "label": "Filter",
+        "name": "filter",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      }
+    ]
   },
   "time": {
     "from": "now-3h",

--- a/grafana/dashboards/p_chain.json
+++ b/grafana/dashboards/p_chain.json
@@ -28,13 +28,15 @@
   "links": [
     {
       "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [
         "Avalanche"
       ],
       "type": "dashboards"
     }
   ],
-  "liveNow": false,
+  "liveNow": true,
   "panels": [
     {
       "datasource": {
@@ -125,7 +127,7 @@
           "exemplar": true,
           "expr": "round(increase(avalanche_snowman_blks_accepted_count{chain=\"P\", job=\"avalanchego\"}[1m]))>0",
           "interval": "",
-          "legendFormat": "Blocks",
+          "legendFormat": "Blocks {{node_id}}",
           "refId": "A"
         }
       ],
@@ -222,7 +224,7 @@
           "exemplar": true,
           "expr": "round(increase(avalanche_snowman_blks_rejected_count{chain=\"P\", job=\"avalanchego\"}[1m]))>0",
           "interval": "",
-          "legendFormat": "Blocks",
+          "legendFormat": "Blocks {{node_id}}",
           "range": true,
           "refId": "A"
         }
@@ -503,7 +505,7 @@
           "exemplar": true,
           "expr": "avalanche_snowman_blks_processing{chain=\"P\", job=\"avalanchego\"}>0",
           "interval": "",
-          "legendFormat": "Blocks",
+          "legendFormat": "Blocks {{node_id}}",
           "refId": "A"
         }
       ],
@@ -594,7 +596,7 @@
           "exemplar": true,
           "expr": "avalanche_snowman_polls{chain=\"P\"} > 0",
           "interval": "",
-          "legendFormat": "Polls",
+          "legendFormat": "Polls {{node_id}}",
           "refId": "A"
         }
       ],
@@ -605,7 +607,7 @@
       "datasource": {
         "type": "prometheus"
       },
-      "description": "Measures how much of each second is being spent handling different kinds of messages on the C-Chain.\nThe value for chits, for example, is the number of seconds spent handling chits messages per second, over the last 30 seconds.",
+      "description": "Measures how much of each second is being spent handling different kinds of messages on the P-Chain.\nThe value for chits, for example, is the number of seconds spent handling chits messages per second, over the last 30 seconds.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -690,7 +692,7 @@
           "exemplar": true,
           "expr": "rate(avalanche_handler_message_handling_time{chain=\"P\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -815,7 +817,7 @@
       "datasource": {
         "type": "prometheus"
       },
-      "description": "Measures how long each kind of request on the C-Chain takes to handle.\nThe value for chits, for example, is how long, in seconds, it takes to handle a chits message.",
+      "description": "Measures how long each kind of request on the P-Chain takes to handle.\nThe value for chits, for example, is how long, in seconds, it takes to handle a chits message.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -883,7 +885,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
@@ -900,7 +902,7 @@
           "exemplar": true,
           "expr": "rate(avalanche_handler_message_handling_time{chain=\"P\", job=\"avalanchego\"}[5m])/rate(avalanche_handler_messages{chain=\"P\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1191,7 +1193,7 @@
           "exemplar": true,
           "expr": "avg_over_time(avalanche_benchlist_benched_weight{chain=\"P\", job=\"avalanchego\"}[15m]) / 10^9",
           "interval": "",
-          "legendFormat": "AVAX Benched",
+          "legendFormat": "AVAX Benched {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1202,7 +1204,7 @@
       "datasource": {
         "type": "prometheus"
       },
-      "description": "Measures how many of each kind of message are received per second on the C-Chain.",
+      "description": "Measures how many of each kind of message are received per second on the P-Chain.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1270,7 +1272,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
@@ -1287,7 +1289,7 @@
           "exemplar": true,
           "expr": "rate(avalanche_handler_messages{chain=\"P\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1302,7 +1304,19 @@
     "Avalanche"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "filters": [],
+        "hide": 0,
+        "label": "Filter",
+        "name": "filter",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/grafana/dashboards/subnets.json
+++ b/grafana/dashboards/subnets.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -26,15 +29,20 @@
   "links": [
     {
       "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [
         "Avalanche"
       ],
       "type": "dashboards"
     }
   ],
-  "liveNow": false,
+  "liveNow": true,
   "panels": [
     {
+      "datasource": {
+        "type": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -97,7 +105,6 @@
         "legend": {
           "calcs": [
             "mean",
-            "lastNotNull",
             "max",
             "min"
           ],
@@ -116,9 +123,9 @@
             "type": "prometheus"
           },
           "exemplar": true,
-          "expr": "round(increase(avalanche_${subnet}_blks_accepted_count{job=\"avalanchego\"}[1m]))>0",
+          "expr": "round(increase(avalanche_snowman_blks_accepted_count{chain=\"${chain_id}\", job=\"avalanchego\"}[1m]))>0",
           "interval": "",
-          "legendFormat": "Accepted",
+          "legendFormat": "Blocks {{node_id}}",
           "refId": "A"
         }
       ],
@@ -193,7 +200,6 @@
         "legend": {
           "calcs": [
             "mean",
-            "lastNotNull",
             "max",
             "min"
           ],
@@ -208,10 +214,13 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus"
+          },
           "exemplar": true,
-          "expr": "round(increase(avalanche_${subnet}_blks_rejected_count{job=\"avalanchego\"}[1m]))>0",
+          "expr": "round(increase(avalanche_blks_rejected_count{chain=\"${chain_id}\", job=\"avalanchego\"}[1m]))>0",
           "interval": "",
-          "legendFormat": "Rejected",
+          "legendFormat": "Blocks {{node_id}}",
           "refId": "A"
         }
       ],
@@ -282,7 +291,6 @@
         "legend": {
           "calcs": [
             "mean",
-            "lastNotNull",
             "max",
             "min"
           ],
@@ -297,9 +305,12 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "expr": "rate(avalanche_${subnet}_blks_accepted_sum{job=\"avalanchego\"}[5m]) / rate(avalanche_${subnet}_blks_accepted_count{job=\"avalanchego\"}[5m])",
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "rate(avalanche_snowman_blks_accepted_sum{chain=\"${chain_id}\", job=\"avalanchego\"}[5m]) / rate(avalanche_snowman_blks_accepted_count{chain=\"${chain_id}\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "Avg Acceptance Latency",
+          "legendFormat": "Avg Acceptance Latency {{node_id}}",
           "refId": "A"
         }
       ],
@@ -373,7 +384,6 @@
         "legend": {
           "calcs": [
             "mean",
-            "lastNotNull",
             "max",
             "min"
           ],
@@ -388,9 +398,12 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "expr": "rate(avalanche_${subnet}_blks_rejected_sum{job=\"avalanchego\"}[5m]) / rate(avalanche_${subnet}_blks_rejected_count{job=\"avalanchego\"}[5m])",
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "rate(avalanche_snowman_blks_rejected_sum{chain=\"${chain_id}\", job=\"avalanchego\"}[5m]) / rate(avalanche_snowman_blks_rejected_count{chain=\"${chain_id}\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "Avg Rejection Latency",
+          "legendFormat": "Avg Rejection Latency {{node_id}}",
           "refId": "A"
         }
       ],
@@ -398,6 +411,9 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -457,7 +473,6 @@
         "legend": {
           "calcs": [
             "mean",
-            "lastNotNull",
             "max"
           ],
           "displayMode": "list",
@@ -475,9 +490,9 @@
             "type": "prometheus"
           },
           "exemplar": true,
-          "expr": "avalanche_${subnet}_blks_processing{job=\"avalanchego\"}>0",
+          "expr": "avalanche_snowman_blks_processing{chain=\"${chain_id}\", job=\"avalanchego\"}>0",
           "interval": "",
-          "legendFormat": "Transactions",
+          "legendFormat": "Blocks {{node_id}}",
           "refId": "A"
         }
       ],
@@ -546,7 +561,6 @@
         "legend": {
           "calcs": [
             "mean",
-            "lastNotNull",
             "max"
           ],
           "displayMode": "list",
@@ -560,10 +574,13 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus"
+          },
           "exemplar": true,
-          "expr": "avalanche_${subnet}_polls > 0",
+          "expr": "avalanche_snowman_polls{chain=\"${chain_id}\"} > 0",
           "interval": "",
-          "legendFormat": "",
+          "legendFormat": "Polls {{node_id}}",
           "refId": "A"
         }
       ],
@@ -640,7 +657,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "bottom"
         },
         "tooltip": {
           "mode": "single",
@@ -650,120 +667,14 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus"
+          },
           "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_pull_query_sum{job=\"avalanchego\"}[5m])",
+          "expr": "rate(avalanche_handler_pull_query_sum{chain=\"${chain_id}\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "pull query",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_push_query_sum{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "push query",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_chits_sum{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "chits",
-          "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_accepted_sum{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "accepted",
-          "refId": "D"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_get_sum{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "get",
-          "refId": "E"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_put_sum{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "put",
-          "refId": "F"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_multiput_sum{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "multiput",
-          "refId": "G"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_get_ancestors_sum{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "get ancestors",
-          "refId": "H"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_get_failed_sum{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "get failed",
-          "refId": "I"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_query_failed_sum{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "query failed",
-          "refId": "J"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_get_accepted_sum{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "get accepted",
-          "refId": "K"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_get_ancestors_failed_sum{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "get ancestors failed",
-          "refId": "L"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_app_request_sum{job=\"avalanchego\"}[5m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "app request",
-          "refId": "M"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_app_request_failed_sum{job=\"avalanchego\"}[5m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "app request failed",
-          "refId": "N"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_app_response_sum{job=\"avalanchego\"}[5m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "app response",
-          "refId": "O"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_app_gossip_sum{job=\"avalanchego\"}[5m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "app gossip",
-          "refId": "P"
         }
       ],
       "title": "Message Handling Time (Total)",
@@ -838,7 +749,6 @@
         "legend": {
           "calcs": [
             "mean",
-            "lastNotNull",
             "max",
             "min"
           ],
@@ -853,11 +763,11 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
-          "exemplar": true,
-          "expr": "(increase(avalanche_${subnet}_handler_chits_count{job=\"avalanchego\"}[5m]) + 1) / (increase(avalanche_${subnet}_handler_chits_count{job=\"avalanchego\"}[5m]) + increase(avalanche_${subnet}_handler_query_failed_count{job=\"avalanchego\"}[5m]) + 1)",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "% Successful",
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "max(increase(avalanche_handler_messages{chain=\"${chain_id}\", op=\"chits\", job=\"avalanchego\"}[5m]))",
+          "hide": true,
           "refId": "A"
         }
       ],
@@ -934,7 +844,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "bottom"
         },
         "tooltip": {
           "mode": "single",
@@ -944,120 +854,14 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus"
+          },
           "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_pull_query_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_pull_query_count{job=\"avalanchego\"}[5m])",
+          "expr": "rate(avalanche_handler_message_handling_time{chain=\"${chain_id}\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "pull query",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_push_query_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_push_query_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "push query",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_chits_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_chits_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "chits",
-          "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_accepted_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_accepted_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "accepted",
-          "refId": "D"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_get_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_get_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "get",
-          "refId": "E"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_put_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_put_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "put",
-          "refId": "F"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_multiput_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_multi_put_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "multiput",
-          "refId": "G"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_get_ancestors_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_get_ancestors_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "get ancestors",
-          "refId": "H"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_get_failed_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_get_failed_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "get failed",
-          "refId": "I"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_query_failed_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_query_failed_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "query failed",
-          "refId": "J"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_get_accepted_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_get_accepted_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "get accepted",
-          "refId": "K"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_get_ancestors_failed_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_get_ancestors_failed_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "get ancestors failed",
-          "refId": "L"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_app_request_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_app_request_count{job=\"avalanchego\"}[5m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "app request",
-          "refId": "M"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_app_request_failed_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_app_request_failed_count{job=\"avalanchego\"}[5m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "app request failed",
-          "refId": "N"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_app_response_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_app_response_count{job=\"avalanchego\"}[5m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "app response",
-          "refId": "O"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_app_gossip_sum{job=\"avalanchego\"}[5m])/rate(avalanche_${subnet}_handler_app_gossip_count{job=\"avalanchego\"}[5m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "app gossip",
-          "refId": "P"
         }
       ],
       "title": "Message Handling Time (per Message)",
@@ -1131,7 +935,6 @@
         "legend": {
           "calcs": [
             "mean",
-            "lastNotNull",
             "max"
           ],
           "displayMode": "list",
@@ -1145,10 +948,13 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus"
+          },
           "exemplar": true,
-          "expr": "avg_over_time(avalanche_${subnet}_benchlist_benched_weight{job=\"avalanchego\"}[15m]) / 10^9",
+          "expr": "avg_over_time(avalanche_benchlist_benched_weight{chain=\"${chain_id}\", job=\"avalanchego\"}[15m]) / 10^9",
           "interval": "",
-          "legendFormat": "AVAX Benched",
+          "legendFormat": "AVAX Benched {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1225,7 +1031,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right"
+          "placement": "bottom"
         },
         "tooltip": {
           "mode": "single",
@@ -1235,126 +1041,23 @@
       "pluginVersion": "8.0.4",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus"
+          },
           "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_pull_query_count{job=\"avalanchego\"}[5m])",
+          "expr": "rate(avalanche_handler_messages{chain=\"${chain_id}\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "pull query",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_push_query_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "push query",
-          "refId": "B"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_chits_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "chits",
-          "refId": "C"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_accepted_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "accepted",
-          "refId": "D"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_get_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "get",
-          "refId": "E"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_put_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "put",
-          "refId": "F"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_multi_put_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "multiput",
-          "refId": "G"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_get_ancestors_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "get ancestors",
-          "refId": "H"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_get_failed_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "get failed",
-          "refId": "I"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_query_failed_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "query failed",
-          "refId": "J"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_get_accepted_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "get accepted",
-          "refId": "K"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_get_ancestors_failed_count{job=\"avalanchego\"}[5m])",
-          "interval": "",
-          "legendFormat": "get ancestors failed",
-          "refId": "L"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_app_request_count{job=\"avalanchego\"}[5m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "app request",
-          "refId": "M"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_app_request_failed_count{job=\"avalanchego\"}[5m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "app request failed",
-          "refId": "N"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_app_response_count{job=\"avalanchego\"}[5m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "app response",
-          "refId": "O"
-        },
-        {
-          "exemplar": true,
-          "expr": "rate(avalanche_${subnet}_handler_app_gossip_count{job=\"avalanchego\"}[5m])",
-          "hide": false,
-          "interval": "",
-          "legendFormat": "app gossip",
-          "refId": "P"
         }
       ],
       "title": "Messages Received per Second",
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "Hit rate for the cache where the key is the byte representation of the block, and the value is the block's ID",
       "fieldConfig": {
         "defaults": {
@@ -1427,17 +1130,44 @@
       },
       "targets": [
         {
-          "exemplar": true,
-          "expr": "increase(avalanche_${subnet}_vm_rpcchainvm_bytes_to_id_cache_hit[5m])/(increase(avalanche_${subnet}_vm_rpcchainvm_bytes_to_id_cache_hit[5m])+increase(avalanche_${subnet}_vm_rpcchainvm_bytes_to_id_cache_miss[5m]))",
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_bytes_to_id_cache_get_count{chain=\"${chain_id}\", result=\"hit\"}[5m]) or 0 * up)",
           "interval": "",
-          "legendFormat": "Hit Rate",
-          "refId": "A"
+          "legendFormat": "Hits {{node_id}}",
+          "refId": "A",
+          "hide": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_bytes_to_id_cache_get_count{chain=\"${chain_id}\"}[5m]) or 0 * up)",
+          "interval": "",
+          "legendFormat": "Calls {{node_id}}",
+          "refId": "B",
+          "hide": true
+        },
+        {
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__",
+            "name": "Expression"
+          },
+          "refId": "Hit Rate",
+          "type": "math",
+          "hide": false,
+          "expression": "$A/$B"
         }
       ],
       "title": "Block ID Cache Hit Rate",
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "Hit rate for the missing block cache",
       "fieldConfig": {
         "defaults": {
@@ -1511,17 +1241,43 @@
       },
       "targets": [
         {
-          "exemplar": true,
-          "expr": "increase(avalanche_${subnet}_vm_rpcchainvm_missing_cache_hit[5m])/(increase(avalanche_${subnet}_vm_rpcchainvm_missing_cache_hit[5m])+increase(avalanche_${subnet}_vm_rpcchainvm_missing_cache_miss[5m]))",
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_missing_cache_get_count{chain=\"${chain_id}\", result=\"hit\"}[5m]) or 0 * up)",
           "interval": "",
-          "legendFormat": "Hit Rate",
-          "refId": "A"
+          "legendFormat": "Hits {{node_id}}",
+          "refId": "A",
+          "hide": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_missing_cache_get_count{chain=\"${chain_id}\"}[5m]) or 0 * up)",
+          "interval": "",
+          "legendFormat": "Calls {{node_id}}",
+          "refId": "B",
+          "hide": true
+        },
+        {
+          "refId": "Hit Rate",
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__",
+            "name": "Expression"
+          },
+          "type": "math",
+          "expression": "$A/$B"
         }
       ],
       "title": "Missing Block Cache Hit Rate",
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "Hit rate for the decided block cache",
       "fieldConfig": {
         "defaults": {
@@ -1594,17 +1350,43 @@
       },
       "targets": [
         {
-          "exemplar": true,
-          "expr": "increase(avalanche_${subnet}_vm_rpcchainvm_decided_cache_hit[5m])/(increase(avalanche_${subnet}_vm_rpcchainvm_decided_cache_hit[5m])+increase(avalanche_${subnet}_vm_rpcchainvm_decided_cache_miss[5m]))",
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_decided_cache_get_count{chain=\"${chain_id}\", result=\"hit\"}[5m]) or 0 * up)",
           "interval": "",
-          "legendFormat": "Hit Rate",
-          "refId": "A"
+          "legendFormat": "Hits {{node_id}}",
+          "refId": "A",
+          "hide": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_decided_cache_get_count{chain=\"${chain_id}\"}[5m]) or 0 * up)",
+          "interval": "",
+          "legendFormat": "Calls {{node_id}}",
+          "refId": "B",
+          "hide": true
+        },
+        {
+          "refId": "Hit Rate",
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__",
+            "name": "Expression"
+          },
+          "type": "math",
+          "expression": "$A/$B"
         }
       ],
       "title": "Decided Cache Hit Rate",
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "Hit rate for the unverified block cache",
       "fieldConfig": {
         "defaults": {
@@ -1677,11 +1459,34 @@
       },
       "targets": [
         {
-          "exemplar": true,
-          "expr": "increase(avalanche_${subnet}_vm_rpcchainvm_unverified_cache_hit[5m])/(increase(avalanche_${subnet}_vm_rpcchainvm_unverified_cache_hit[5m])+increase(avalanche_${subnet}_vm_rpcchainvm_unverified_cache_miss[5m]))",
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_unverified_cache_get_count{chain=\"${chain_id}\", result=\"hit\"}[5m]) or 0 * up)",
           "interval": "",
-          "legendFormat": "Hit Rate",
-          "refId": "A"
+          "legendFormat": "Hits {{node_id}}",
+          "refId": "A",
+          "hide": true
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_unverified_cache_get_count{chain=\"${chain_id}\"}[5m]) or 0 * up)",
+          "interval": "",
+          "legendFormat": "Calls {{node_id}}",
+          "refId": "B",
+          "hide": true
+        },
+        {
+          "refId": "Hit Rate",
+          "datasource": {
+            "type": "__expr__",
+            "uid": "__expr__",
+            "name": "Expression"
+          },
+          "type": "math",
+          "expression": "$A/$B"
         }
       ],
       "title": "Unverified Block Cache Hit Rate",
@@ -1767,17 +1572,33 @@
       "pluginVersion": "8.0.6",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus"
+          },
           "exemplar": true,
-          "expr": "avalanche_${subnet}_handler_unprocessed_msgs_len",
+          "expr": "avalanche_handler_sync_unprocessed_msgs_count{chain=\"${chain_id}\", job=\"avalanchego\"}",
           "interval": "",
-          "legendFormat": "Pending Messages",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "exemplar": true,
+          "expr": "avalanche_handler_async_unprocessed_msgs_count{chain=\"${chain_id}\", job=\"avalanchego\"}",
+          "interval": "",
+          "legendFormat": "{{ op }} {{node_id}}",
+          "refId": "B"
         }
       ],
       "title": "Unprocessed Incoming Messages",
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1839,10 +1660,6 @@
       "id": 29,
       "options": {
         "legend": {
-          "calcs": [
-            "mean",
-            "max"
-          ],
           "displayMode": "list",
           "placement": "bottom"
         },
@@ -1854,10 +1671,13 @@
       "pluginVersion": "8.0.6",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus"
+          },
           "exemplar": true,
-          "expr": "increase(avalanche_${subnet}_handler_expired[1m])",
+          "expr": "increase(avalanche_handler_expired{chain=\"${chain_id}\", job=\"avalanchego\"}[1m])",
           "interval": "",
-          "legendFormat": "Expired",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1874,33 +1694,59 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": true,
-          "text": "Spaces (Fuji)",
-          "value": "2ebCneCbwthjQ1rYT41nhd7M76Hc6YmosMAQrTFhBq8qeqh6tt"
+        "current": {},
+        "datasource": {
+          "type": "prometheus"
         },
-        "description": "This is a list of popular/known subnets. Your node may not be syncing these subnets in which case you will se no data.",
+        "definition": "metrics(avalanche_.*_rpcchainvm.*)",
+        "description": "",
+        "hide": 1,
+        "includeAll": false,
+        "label": "VM Type",
+        "multi": false,
+        "name": "vm_type",
+        "options": [],
+        "query": {
+          "qryType": 2,
+          "query": "metrics(avalanche_.*_rpcchainvm.*)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/avalanche_(?<value>[^_]+).*/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "definition": "label_values(chain)",
         "hide": 0,
         "includeAll": false,
-        "label": "Subnet",
+        "label": "Chain",
         "multi": false,
-        "name": "subnet",
-        "options": [
-          {
-            "selected": true,
-            "text": "Spaces (Fuji)",
-            "value": "2ebCneCbwthjQ1rYT41nhd7M76Hc6YmosMAQrTFhBq8qeqh6tt"
-          },
-          {
-            "selected": false,
-            "text": "WAGMI (Fuji)",
-            "value": "2AM3vsuLoJdGBGqX2ibE8RGEq4Lg7g4bot6BT1Z7B9dH5corUD"
-          }
-        ],
-        "query": "Spaces (Fuji) : 2ebCneCbwthjQ1rYT41nhd7M76Hc6YmosMAQrTFhBq8qeqh6tt, WAGMI (Fuji) : 2AM3vsuLoJdGBGqX2ibE8RGEq4Lg7g4bot6BT1Z7B9dH5corUD",
-        "queryValue": "",
+        "name": "chain_id",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(chain)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
         "skipUrlSync": false,
-        "type": "custom"
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "filters": [],
+        "hide": 0,
+        "label": "Filter",
+        "name": "filter",
+        "skipUrlSync": false,
+        "type": "adhoc"
       }
     ]
   },

--- a/grafana/dashboards/subnets.json
+++ b/grafana/dashboards/subnets.json
@@ -671,7 +671,7 @@
             "type": "prometheus"
           },
           "exemplar": true,
-          "expr": "rate(avalanche_handler_pull_query_sum{chain=\"${chain_id}\", job=\"avalanchego\"}[5m])",
+          "expr": "rate(avalanche_handler_message_handling_time{chain=\"${chain_id}\", job=\"avalanchego\"}[5m])",
           "interval": "",
           "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
@@ -1133,7 +1133,7 @@
           "datasource": {
             "type": "prometheus"
           },
-          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_bytes_to_id_cache_get_count{chain=\"${chain_id}\", result=\"hit\"}[5m]) or 0 * up)",
+          "expr": "sum(increase(avalanche_rpcchainvm_bytes_to_id_cache_get_count{chain=\"${chain_id}\", result=\"hit\"}[5m]) or 0 * up)",
           "interval": "",
           "legendFormat": "Hits {{node_id}}",
           "refId": "A",
@@ -1143,7 +1143,7 @@
           "datasource": {
             "type": "prometheus"
           },
-          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_bytes_to_id_cache_get_count{chain=\"${chain_id}\"}[5m]) or 0 * up)",
+          "expr": "sum(increase(avalanche_rpcchainvm_bytes_to_id_cache_get_count{chain=\"${chain_id}\"}[5m]) or 0 * up)",
           "interval": "",
           "legendFormat": "Calls {{node_id}}",
           "refId": "B",
@@ -1244,7 +1244,7 @@
           "datasource": {
             "type": "prometheus"
           },
-          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_missing_cache_get_count{chain=\"${chain_id}\", result=\"hit\"}[5m]) or 0 * up)",
+          "expr": "sum(increase(avalanche_rpcchainvm_missing_cache_get_count{chain=\"${chain_id}\", result=\"hit\"}[5m]) or 0 * up)",
           "interval": "",
           "legendFormat": "Hits {{node_id}}",
           "refId": "A",
@@ -1254,7 +1254,7 @@
           "datasource": {
             "type": "prometheus"
           },
-          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_missing_cache_get_count{chain=\"${chain_id}\"}[5m]) or 0 * up)",
+          "expr": "sum(increase(avalanche_rpcchainvm_missing_cache_get_count{chain=\"${chain_id}\"}[5m]) or 0 * up)",
           "interval": "",
           "legendFormat": "Calls {{node_id}}",
           "refId": "B",
@@ -1353,7 +1353,7 @@
           "datasource": {
             "type": "prometheus"
           },
-          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_decided_cache_get_count{chain=\"${chain_id}\", result=\"hit\"}[5m]) or 0 * up)",
+          "expr": "sum(increase(avalanche_rpcchainvm_decided_cache_get_count{chain=\"${chain_id}\", result=\"hit\"}[5m]) or 0 * up)",
           "interval": "",
           "legendFormat": "Hits {{node_id}}",
           "refId": "A",
@@ -1363,7 +1363,7 @@
           "datasource": {
             "type": "prometheus"
           },
-          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_decided_cache_get_count{chain=\"${chain_id}\"}[5m]) or 0 * up)",
+          "expr": "sum(increase(avalanche_rpcchainvm_decided_cache_get_count{chain=\"${chain_id}\"}[5m]) or 0 * up)",
           "interval": "",
           "legendFormat": "Calls {{node_id}}",
           "refId": "B",
@@ -1462,7 +1462,7 @@
           "datasource": {
             "type": "prometheus"
           },
-          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_unverified_cache_get_count{chain=\"${chain_id}\", result=\"hit\"}[5m]) or 0 * up)",
+          "expr": "sum(increase(avalanche_rpcchainvm_unverified_cache_get_count{chain=\"${chain_id}\", result=\"hit\"}[5m]) or 0 * up)",
           "interval": "",
           "legendFormat": "Hits {{node_id}}",
           "refId": "A",
@@ -1472,7 +1472,7 @@
           "datasource": {
             "type": "prometheus"
           },
-          "expr": "sum(increase(avalanche_${vm_type}_rpcchainvm_unverified_cache_get_count{chain=\"${chain_id}\"}[5m]) or 0 * up)",
+          "expr": "sum(increase(avalanche_rpcchainvm_unverified_cache_get_count{chain=\"${chain_id}\"}[5m]) or 0 * up)",
           "interval": "",
           "legendFormat": "Calls {{node_id}}",
           "refId": "B",
@@ -1693,30 +1693,6 @@
   ],
   "templating": {
     "list": [
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus"
-        },
-        "definition": "metrics(avalanche_.*_rpcchainvm.*)",
-        "description": "",
-        "hide": 1,
-        "includeAll": false,
-        "label": "VM Type",
-        "multi": false,
-        "name": "vm_type",
-        "options": [],
-        "query": {
-          "qryType": 2,
-          "query": "metrics(avalanche_.*_rpcchainvm.*)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 2,
-        "regex": "/avalanche_(?<value>[^_]+).*/",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
       {
         "current": {},
         "definition": "label_values(chain)",

--- a/grafana/dashboards/x_chain.json
+++ b/grafana/dashboards/x_chain.json
@@ -28,13 +28,15 @@
   "links": [
     {
       "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
       "tags": [
         "Avalanche"
       ],
       "type": "dashboards"
     }
   ],
-  "liveNow": false,
+  "liveNow": true,
   "panels": [
     {
       "datasource": {
@@ -125,7 +127,7 @@
           "exemplar": true,
           "expr": "round(increase(avalanche_snowman_blks_accepted_count{chain=\"X\", job=\"avalanchego\"}[1m]))>0",
           "interval": "",
-          "legendFormat": "Blocks",
+          "legendFormat": "Blocks {{node_id}}",
           "refId": "A"
         }
       ],
@@ -222,7 +224,7 @@
           "exemplar": true,
           "expr": "round(increase(avalanche_snowman_blks_rejected_count{chain=\"X\", job=\"avalanchego\"}[1m]))>0",
           "interval": "",
-          "legendFormat": "Blocks",
+          "legendFormat": "Blocks {{node_id}}",
           "range": true,
           "refId": "A"
         }
@@ -316,7 +318,7 @@
           },
           "expr": "rate(avalanche_snowman_blks_accepted_sum{chain=\"X\", job=\"avalanchego\"}[5m]) / rate(avalanche_snowman_blks_accepted_count{chain=\"X\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "Avg Acceptance Latency",
+          "legendFormat": "Avg Acceptance Latency {{node_id}}",
           "refId": "A"
         }
       ],
@@ -412,7 +414,7 @@
           },
           "expr": "rate(avalanche_snowman_blks_rejected_sum{chain=\"X\", job=\"avalanchego\"}[5m]) / rate(avalanche_snowman_blks_rejected_count{chain=\"X\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "Avg Rejection Latency",
+          "legendFormat": "Avg Rejection Latency {{node_id}}",
           "refId": "A"
         }
       ],
@@ -503,7 +505,7 @@
           "exemplar": true,
           "expr": "avalanche_snowman_blks_processing{chain=\"X\", job=\"avalanchego\"}>0",
           "interval": "",
-          "legendFormat": "Blocks",
+          "legendFormat": "Blocks {{node_id}}",
           "refId": "A"
         }
       ],
@@ -594,7 +596,7 @@
           "exemplar": true,
           "expr": "avalanche_snowman_polls{chain=\"X\"} > 0",
           "interval": "",
-          "legendFormat": "Polls",
+          "legendFormat": "Polls {{node_id}}",
           "refId": "A"
         }
       ],
@@ -605,7 +607,7 @@
       "datasource": {
         "type": "prometheus"
       },
-      "description": "Measures how much of each second is being spent handling different kinds of messages on the C-Chain.\nThe value for chits, for example, is the number of seconds spent handling chits messages per second, over the last 30 seconds.",
+      "description": "Measures how much of each second is being spent handling different kinds of messages on the X-Chain.\nThe value for chits, for example, is the number of seconds spent handling chits messages per second, over the last 30 seconds.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -673,7 +675,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
@@ -690,7 +692,7 @@
           "exemplar": true,
           "expr": "rate(avalanche_handler_message_handling_time{chain=\"X\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -815,7 +817,7 @@
       "datasource": {
         "type": "prometheus"
       },
-      "description": "Measures how long each kind of request on the C-Chain takes to handle.\nThe value for chits, for example, is how long, in seconds, it takes to handle a chits message.",
+      "description": "Measures how long each kind of request on the X-Chain takes to handle.\nThe value for chits, for example, is how long, in seconds, it takes to handle a chits message.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -883,7 +885,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
@@ -900,7 +902,7 @@
           "exemplar": true,
           "expr": "rate(avalanche_handler_message_handling_time{chain=\"X\", job=\"avalanchego\"}[5m])/rate(avalanche_handler_messages{chain=\"X\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -992,7 +994,7 @@
           "exemplar": true,
           "expr": "avalanche_handler_sync_unprocessed_msgs_count{chain=\"X\"}",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         },
         {
@@ -1002,7 +1004,7 @@
           "exemplar": true,
           "expr": "avalanche_handler_async_unprocessed_msgs_count{chain=\"X\"}",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "B"
         }
       ],
@@ -1094,7 +1096,7 @@
           "exemplar": true,
           "expr": "increase(avalanche_handler_expired{chain=\"X\", job=\"avalanchego\"}[1m]) or 0 * up",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1191,7 +1193,7 @@
           "exemplar": true,
           "expr": "avg_over_time(avalanche_benchlist_benched_weight{chain=\"X\", job=\"avalanchego\"}[15m]) / 10^9",
           "interval": "",
-          "legendFormat": "AVAX Benched",
+          "legendFormat": "AVAX Benched {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1202,7 +1204,7 @@
       "datasource": {
         "type": "prometheus"
       },
-      "description": "Measures how many of each kind of message are received per second on the C-Chain.",
+      "description": "Measures how many of each kind of message are received per second on the X-Chain.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1270,7 +1272,7 @@
             "max"
           ],
           "displayMode": "table",
-          "placement": "right",
+          "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
@@ -1287,7 +1289,7 @@
           "exemplar": true,
           "expr": "rate(avalanche_handler_messages{chain=\"X\", job=\"avalanchego\"}[5m])",
           "interval": "",
-          "legendFormat": "{{ op }}",
+          "legendFormat": "{{ op }} {{node_id}}",
           "refId": "A"
         }
       ],
@@ -1302,7 +1304,19 @@
     "Avalanche"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "datasource": {
+          "type": "prometheus"
+        },
+        "filters": [],
+        "hide": 0,
+        "label": "Filter",
+        "name": "filter",
+        "skipUrlSync": false,
+        "type": "adhoc"
+      }
+    ]
   },
   "time": {
     "from": "now-6h",


### PR DESCRIPTION
- add `Filter` variable to allow ad-hoc filtering of all queries either manually or via url

- set `includeVars` and `keepTime` to ensure that clicking between a pair of dashboards results in the same data being displayed

- set `liveNow` to true

- update panel legends to include node id where applicable

- ensure all legends are placed at the bottom to ensure legibility for long labels that include the node id

- update subnet dashboard to filter by dynamically populated chain id variable (previously the variable needed to be manually populated)

- ensure that all datasource references are to 'prometheus'