### PR TITLE
Granular C-Chain Processing View

### DIFF
--- a/grafana/dashboards/c_chain_processing.json
+++ b/grafana/dashboards/c_chain_processing.json
@@ -686,7 +686,7 @@
     },
     "timepicker": {},
     "timezone": "",
-    "title": "Avalanche C-Chain Processing Metrics (Custom)",
+    "title": "C-Chain Processing",
     "uid": "c-chain-processing-custom-v8",
     "version": 8
   }


### PR DESCRIPTION
This PR adds a more granular C-Chain metrics dashboard. Preview here: https://grafana-poc.avax-dev.network/d/c-chain-processing-custom-v8/avalanche-c-chain-processing-metrics-custom?orgId=1&from=2025-07-08T14:18:42.763Z&to=2025-07-08T14:21:06.047Z&timezone=browser&var-datasource=P1809F7CD0C75ACF3&var-filter=gh_run_id%7C%3D%7C16145632981&var-chain=C&refresh=10s